### PR TITLE
Add additional warnings for Google Maps API usage

### DIFF
--- a/index.js
+++ b/index.js
@@ -142,8 +142,16 @@ module.exports = {
   },
 
   buildGoogleMapsUrl(config) {
-    if (!(config && config.key)) {
-      this.warn('You must provide at least a Google Maps API key to ember-google-maps. Learn more: https://ember-google-maps.sandydoo.me/docs/getting-started');
+    if (!(config && config.key) || !(config && config.client)) {
+      this.warn('You must provide either a Google Maps API key or a Google Maps Premium Plan Client ID to ember-google-maps. Learn more: https://ember-google-maps.sandydoo.me/docs/getting-started');
+    }
+    
+    if (config && config.key && config.client) {
+      this.warn('You must specify either a Google Maps API key or a Google Maps Premium Plan Client ID, but not both. Learn more: https://ember-google-maps.sandydoo.me/docs/getting-started');
+    }
+    
+    if (config && config.channel && !config.client) {
+      this.warn('The Google Maps API channel parameter is only available when using a client ID, not when using an API key. Learn more: https://ember-google-maps.sandydoo.me/docs/getting-started');
     }
 
     let src = config.baseUrl || '//maps.googleapis.com/maps/api/js';

--- a/index.js
+++ b/index.js
@@ -142,15 +142,17 @@ module.exports = {
   },
 
   buildGoogleMapsUrl(config) {
-    if (!(config && config.key) || !(config && config.client)) {
+    config = config || {};
+    
+    if (!config.key && !config.client) {
       this.warn('You must provide either a Google Maps API key or a Google Maps Premium Plan Client ID to ember-google-maps. Learn more: https://ember-google-maps.sandydoo.me/docs/getting-started');
     }
     
-    if (config && config.key && config.client) {
+    if (config.key && config.client) {
       this.warn('You must specify either a Google Maps API key or a Google Maps Premium Plan Client ID, but not both. Learn more: https://ember-google-maps.sandydoo.me/docs/getting-started');
     }
     
-    if (config && config.channel && !config.client) {
+    if (config.channel && !config.client) {
       this.warn('The Google Maps API channel parameter is only available when using a client ID, not when using an API key. Learn more: https://ember-google-maps.sandydoo.me/docs/getting-started');
     }
 


### PR DESCRIPTION
This PR adds some additional warnings when the google maps API configuration seems incorrect. 
The Google API Client ID can be used instead of the API Key, and they can not be used at the same time.
The channel parameter can only be used when using a Client ID.
https://developers.google.com/maps/documentation/javascript/get-api-key#premium-auth