### PR TITLE
Improve the public API object

### DIFF
--- a/addon/components/g-map/directions.js
+++ b/addon/components/g-map/directions.js
@@ -31,8 +31,13 @@ export default MapComponent.extend({
     this._super(...arguments);
     this.waypoints = A();
 
-    this.publicAPI.waypoints = this.waypoints;
-    this.publicAPI.actions.route = () => this.route();
+    this.publicAPI.reopen({
+      directions: 'directions',
+      waypoints: 'waypoints',
+      actions: {
+        route: 'route'
+      }
+    });
   },
 
   _addComponent() {
@@ -45,19 +50,18 @@ export default MapComponent.extend({
 
   route() {
     return this._route().then((directions) => {
-      const newDirections = {
+      setProperties(this, {
         directions,
         mapComponent: directions
-      };
-      setProperties(this, newDirections);
-      setProperties(this.publicAPI, newDirections);
+      });
+
       tryInvoke(this, 'onDirectionsChanged', [this.publicAPI]);
     });
   },
 
   _route() {
     return get(this, 'directionsService').then((directionsService) => {
-      const options = get(this, '_options');
+      let options = get(this, '_options');
       delete options.map;
 
       return new Promise((resolve, reject) => {

--- a/addon/components/g-map/info-window.js
+++ b/addon/components/g-map/info-window.js
@@ -1,7 +1,7 @@
 import MapComponent from './map-component';
 import layout from '../../templates/components/g-map/info-window';
 import { position } from '../../utils/helpers';
-import { get, set, setProperties } from '@ember/object';
+import { get, set } from '@ember/object';
 
 /**
  * A wrapper for the google.maps.InfoWindow class.
@@ -29,9 +29,12 @@ export default MapComponent.extend({
     if (!get(this, 'target')) {
       this._requiredOptions = this._requiredOptions.concat(['position']);
     }
-    setProperties(this.publicAPI.actions, {
-      open: () => this.open(),
-      close: () => this.close()
+
+    this.publicAPI.reopen({
+      actions: {
+        open: 'open',
+        close: 'close'
+      }
     });
   },
 

--- a/addon/utils/public-api.js
+++ b/addon/utils/public-api.js
@@ -1,0 +1,66 @@
+/* eslint-disable object-shorthand */
+
+import { get } from '@ember/object';
+
+// Private properties
+let proxy, revoke;
+
+/**
+ * Create a public API object whose properties map to private properties on a
+ * target object.
+ *
+ * The class constructor accepts two arguments: instance and schema.
+ *
+ * The instance is the object that will serve as the target or proxy for any
+ * getters defined on the public API.
+ *
+ * The schema is an object that defines the structure of public API. The keys
+ * define which properties will be exposed by the class, while the values are
+ * strings that map to properties on the proxy.
+ *
+ * @class PublicAPI
+ * @module ember-google-maps/utils/public-api
+ * @namespace Utils
+ */
+export default class PublicAPI {
+  constructor(instance, schema) {
+    ({ proxy, revoke } = Proxy.revocable(instance, this));
+
+    this.defineProxyProperty(schema, proxy);
+  }
+
+  get(target, prop) {
+    if (target.isDestroyed || target.isDestroying) {
+      revoke();
+      throw Error(`Cannot access property ${prop} on the instance because it has been destroyed.`);
+    }
+
+    if (typeof target[prop] === 'function') {
+      return target[prop].bind(target);
+    }
+
+    return get(target, prop);
+  }
+
+  defineProxyProperty(schema, proxy, target = this) {
+    Object.keys(schema).forEach((prop) => {
+      let descriptor = { configurable: true };
+      let pointer = schema[prop];
+
+      if (typeof pointer === 'object') {
+        let nestedProp = (Object.hasOwnProperty(this, prop)) ? this[prop] : {};
+        this.defineProxyProperty(pointer, proxy, nestedProp);
+        descriptor['get'] = function() { return nestedProp; };
+      } else {
+        descriptor['get'] = function() { return proxy[pointer]; };
+      }
+
+      Object.defineProperty(target, prop, descriptor);
+    });
+  }
+
+  reopen(schema) {
+    this.defineProxyProperty(schema, proxy);
+    return this;
+  }
+}

--- a/tests/integration/components/g-map-test.js
+++ b/tests/integration/components/g-map-test.js
@@ -9,7 +9,7 @@ moduleForMap('Integration | Component | g map', function() {
       {{g-map lat=lat lng=lng zoom=12}}
     `);
 
-    const { map } = await this.get('map');
+    let { map } = await this.get('map');
     assert.ok(map, 'map initialized');
   });
 
@@ -18,7 +18,7 @@ moduleForMap('Integration | Component | g map', function() {
       {{g-map lat=lat lng=lng zoom=12 zoomControl=false}}
     `);
 
-    const { map } = await this.get('map');
+    let { map } = await this.get('map');
     assert.notOk(map.zoomControl, 'zoom control disabled');
   });
 
@@ -29,7 +29,7 @@ moduleForMap('Integration | Component | g map', function() {
       {{g-map lat=lat lng=lng zoom=zoom}}
     `);
 
-    const { map } = await this.get('map');
+    let { map } = await this.get('map');
 
     assert.equal(map.zoom, this.zoom);
 
@@ -49,7 +49,7 @@ moduleForMap('Integration | Component | g map', function() {
       {{g-map lat=lat lng=lng zoom=12 onZoomChanged=(action onZoomChanged)}}
     `);
 
-    const { map } = await this.get('map');
+    let { map } = await this.get('map');
 
     map.setZoom(10);
   });

--- a/tests/integration/components/g-map/autocomplete-test.js
+++ b/tests/integration/components/g-map/autocomplete-test.js
@@ -13,12 +13,12 @@ moduleForMap('Integration | Component | g map/autocomplete', function() {
       {{/g-map}}
     `);
 
-    const { publicAPI } = await this.get('map');
+    let { components } = await this.get('map');
 
-    const input = find('input');
+    let input = find('input');
     assert.ok(input, 'input rendered');
     assert.equal(input.id, 'pac-input');
-    assert.equal(publicAPI.autocompletes.length, 1);
+    assert.equal(components.autocompletes.length, 1);
   });
 
   test('it calls an action on input', async function(assert) {
@@ -50,10 +50,10 @@ moduleForMap('Integration | Component | g map/autocomplete', function() {
       {{/g-map}}
     `);
 
-    const { publicAPI } = await this.get('map');
+    let { components } = await this.get('map');
     // Fetch the initialized Autocomplete component and shim the getPlace
     // function.
-    const autocomplete = publicAPI.autocompletes[0].mapComponent;
+    let autocomplete = components.autocompletes[0].mapComponent;
     autocomplete.getPlace = () => { return { geometry: true }; };
 
     trigger(autocomplete, 'place_changed');

--- a/tests/integration/components/g-map/circle-test.js
+++ b/tests/integration/components/g-map/circle-test.js
@@ -11,9 +11,9 @@ moduleForMap('Integration | Component | g map/circle', function() {
       {{/g-map}}
     `);
 
-    let { publicAPI, map } = await this.get('map');
+    let { map, components } = await this.get('map');
 
-    assert.equal(publicAPI.circles.length, 1);
-    assert.equal(publicAPI.circles[0].mapComponent.map, map);
+    assert.equal(components.circles.length, 1);
+    assert.equal(components.circles[0].mapComponent.map, map);
   });
 });

--- a/tests/integration/components/g-map/control-test.js
+++ b/tests/integration/components/g-map/control-test.js
@@ -13,14 +13,14 @@ moduleForMap('Integration | Component | g map/control', function() {
       {{/g-map}}
     `);
 
-    const { map, publicAPI } = await this.get('map');
+    let { map, components } = await this.get('map');
 
-    assert.equal(publicAPI.controls.length, 1);
+    assert.equal(components.controls.length, 1);
 
-    const control = await waitFor('#custom-control');
+    let control = await waitFor('#custom-control');
     assert.ok(control, 'control rendered');
 
-    const controls = map.controls[google.maps.ControlPosition.TOP_CENTER];
-    assert.equal(publicAPI.controls[0].mapComponent, controls.getAt(0), 'control rendered in correct position');
+    let controls = map.controls[google.maps.ControlPosition.TOP_CENTER];
+    assert.equal(components.controls[0].mapComponent, controls.getAt(0), 'control rendered in correct position');
   });
 });

--- a/tests/integration/components/g-map/directions-test.js
+++ b/tests/integration/components/g-map/directions-test.js
@@ -14,11 +14,11 @@ moduleForMap('Integration | Component | g-map/directions', function() {
       {{/g-map}}
     `);
 
-    const { publicAPI } = await this.get('map');
+    let { components } = await this.get('map');
 
-    assert.equal(publicAPI.directions.length, 1);
-    const request = publicAPI.directions[0].directions.request;
-    const { origin: { query: origin }, destination: { query: destination } } = request;
+    assert.equal(components.directions.length, 1);
+    let request = components.directions[0].directions.request;
+    let { origin: { query: origin }, destination: { query: destination } } = request;
     assert.equal(origin, this.origin);
     assert.equal(destination, this.destination);
   });
@@ -34,17 +34,17 @@ moduleForMap('Integration | Component | g-map/directions', function() {
       {{/g-map}}
     `);
 
-    const { publicAPI } = await this.get('map');
+    let { components } = await this.get('map');
 
     this.set('onDirectionsChanged', () => this.set('directionsChanged', true));
 
     this.set('origin', 'Holborn Station');
 
-    const directionsChanged = () => this.get('directionsChanged');
+    let directionsChanged = () => this.get('directionsChanged');
     await waitUntil(directionsChanged, { timeout: 10000 });
 
-    const request = publicAPI.directions[0].directions.request;
-    const { origin: { query: origin }, destination: { query: destination } } = request;
+    let request = components.directions[0].directions.request;
+    let { origin: { query: origin }, destination: { query: destination } } = request;
     assert.equal(origin, this.origin);
     assert.equal(destination, this.destination);
   });

--- a/tests/integration/components/g-map/info-window-test.js
+++ b/tests/integration/components/g-map/info-window-test.js
@@ -11,11 +11,11 @@ moduleForMap('Integration | Component | g-map/info-window', function() {
       {{/g-map}}
     `);
 
-    let { publicAPI } = await this.get('map');
+    let { components } = await this.get('map');
 
-    assert.equal(publicAPI.infoWindows.length, 1);
+    assert.equal(components.infoWindows.length, 1);
 
-    const infoWindow = publicAPI.infoWindows[0].mapComponent;
+    let infoWindow = components.infoWindows[0].mapComponent;
     assert.ok(infoWindow);
   });
 
@@ -30,8 +30,8 @@ moduleForMap('Integration | Component | g-map/info-window', function() {
       {{/g-map}}
     `);
 
-    let { publicAPI } = await this.get('map');
-    const infoWindow = publicAPI.infoWindows[0].mapComponent;
+    let { components } = await this.get('map');
+    let infoWindow = components.infoWindows[0].mapComponent;
     infoWindow.open = () => assert.ok('info window opened');
 
     this.set('isOpen', true);
@@ -93,18 +93,18 @@ moduleForMap('Integration | Component | g-map/info-window', function() {
       {{/g-map}}
     `);
 
-    const { publicAPI } = await this.get('map');
+    let { components } = await this.get('map');
 
     this.set('isOpen', true);
 
-    const domIsReady = () => this.domIsReady;
+    let domIsReady = () => this.domIsReady;
     await waitUntil(domIsReady);
 
     // There is some lag between the infoWindow rendering and updating its
     // position. It's probably not worth investigating, so we just wait a bit.
     await wait(500);
 
-    const infoWindow = publicAPI.infoWindows[0].mapComponent;
+    let infoWindow = components.infoWindows[0].mapComponent;
     assert.deepEqual(infoWindow.getPosition().toJSON(), { lat: 55, lng: 2 });
   });
 
@@ -122,7 +122,7 @@ moduleForMap('Integration | Component | g-map/info-window', function() {
 
     await this.get('map');
 
-    const domIsReady = () => this.domIsReady;
+    let domIsReady = () => this.domIsReady;
     await waitUntil(domIsReady);
 
     assert.ok(find('#info-window-test'), 'info window open');
@@ -144,10 +144,10 @@ moduleForMap('Integration | Component | g-map/info-window', function() {
       {{/g-map}}
     `);
 
-    const { publicAPI } = await this.get('map');
-    const infoWindow = publicAPI.infoWindows[0].mapComponent;
+    let { components } = await this.get('map');
+    let infoWindow = components.infoWindows[0].mapComponent;
 
-    const domIsReady = () => this.domIsReady;
+    let domIsReady = () => this.domIsReady;
     await waitUntil(domIsReady);
 
     assert.ok(find('#info-window-test'), 'info window open');

--- a/tests/integration/components/g-map/marker-test.js
+++ b/tests/integration/components/g-map/marker-test.js
@@ -11,10 +11,10 @@ moduleForMap('Integration | Component | g map/marker', function() {
       {{/g-map}}
     `);
 
-    let { publicAPI, map } = await this.get('map');
+    let { components, map } = await this.get('map');
 
-    assert.equal(publicAPI.markers.length, 1);
-    assert.equal(publicAPI.markers[0].mapComponent.map, map);
+    assert.equal(components.markers.length, 1);
+    assert.equal(components.markers[0].mapComponent.map, map);
   });
 
   test('it attaches an event to a marker', async function(assert) {
@@ -28,9 +28,9 @@ moduleForMap('Integration | Component | g map/marker', function() {
       {{/g-map}}
     `);
 
-    const { publicAPI } = await this.get('map');
+    let { components } = await this.get('map');
 
-    const marker = publicAPI.markers[0].mapComponent;
+    let marker = components.markers[0].mapComponent;
     trigger(marker, 'click');
   });
 
@@ -41,9 +41,9 @@ moduleForMap('Integration | Component | g map/marker', function() {
       {{/g-map}}
     `);
 
-    const { publicAPI } = await this.get('map');
+    let { components } = await this.get('map');
 
-    const marker = publicAPI.markers[0].mapComponent;
+    let marker = components.markers[0].mapComponent;
     assert.equal(marker.draggable, true);
   });
 });

--- a/tests/integration/components/g-map/overlay-test.js
+++ b/tests/integration/components/g-map/overlay-test.js
@@ -28,14 +28,14 @@ moduleForMap('Integration | Component | g map/overlay', function(hooks) {
       {{/g-map}}
     `);
 
-    const { publicAPI } = await this.get('map');
+    let { id, components } = await this.get('map');
 
-    assert.equal(publicAPI.overlays.length, 1, 'overlay registered');
+    assert.equal(components.overlays.length, 1, 'overlay registered');
 
-    const overlay = await waitFor('#custom-overlay');
+    let overlay = await waitFor('#custom-overlay');
     assert.ok(overlay, 'overlay rendered');
 
-    const mapDiv = find(`#${publicAPI.id}`);
+    let mapDiv = find(`#${id}`);
     assert.ok(mapDiv.contains(overlay), 'overlay is child of map node');
   });
 });

--- a/tests/integration/components/g-map/polyline-test.js
+++ b/tests/integration/components/g-map/polyline-test.js
@@ -19,11 +19,11 @@ moduleForMap('Integration | Component | g map/polyline', function() {
       {{/g-map}}
     `);
 
-    const { publicAPI } = await this.get('map');
-    const polyline = publicAPI.polylines[0].mapComponent;
+    let { components } = await this.get('map');
+    let polyline = components.polylines[0].mapComponent;
     assert.ok(polyline, 'polyline exists');
 
-    const newCoords = { lat: 51.500154286474746, lng: 0.05218505859375 };
+    let newCoords = { lat: 51.500154286474746, lng: 0.05218505859375 };
     this.get('path').pushObject(newCoords);
 
     assert.deepEqual(polyline.getPath().getAt(4).toJSON(), newCoords);

--- a/tests/integration/components/g-map/route-test.js
+++ b/tests/integration/components/g-map/route-test.js
@@ -16,9 +16,9 @@ moduleForMap('Integration | Component | g-map/route', function() {
       {{/g-map}}
     `);
 
-    const { publicAPI } = await this.get('map');
+    let { components } = await this.get('map');
 
-    assert.equal(publicAPI.routes.length, 1);
+    assert.equal(components.routes.length, 1);
   });
 
   test('it updates a route when the directions change', async function(assert) {
@@ -34,14 +34,14 @@ moduleForMap('Integration | Component | g-map/route', function() {
       {{/g-map}}
     `);
 
-    const { publicAPI } = await this.get('map');
+    let { components } = await this.get('map');
 
     this.set('onDirectionsChanged', () => this.set('directionsChanged', true));
     this.set('origin', 'Holborn Station');
-    const directionsChanged = () => this.get('directionsChanged');
+    let directionsChanged = () => this.get('directionsChanged');
     await waitUntil(directionsChanged, { timeout: 10000 });
 
-    const route = publicAPI.routes[0].mapComponent;
+    let route = components.routes[0].mapComponent;
     assert.equal(route.directions.request.origin.query, this.origin);
   });
 });

--- a/tests/integration/components/g-map/waypoint-test.js
+++ b/tests/integration/components/g-map/waypoint-test.js
@@ -17,9 +17,9 @@ moduleForMap('Integration | Component | g-map/waypoint', function() {
       {{/g-map}}
     `);
 
-    const { publicAPI } = await this.get('map');
+    let { components } = await this.get('map');
 
-    const request = publicAPI.directions[0].directions.request;
+    let request = components.directions[0].directions.request;
 
     assert.equal(request.waypoints.length, 1);
     assert.equal(request.waypoints[0].location.query, this.waypointLocation);
@@ -42,18 +42,17 @@ moduleForMap('Integration | Component | g-map/waypoint', function() {
       {{/g-map}}
     `);
 
-    const { publicAPI } = await this.get('map');
+    let { components } = await this.get('map');
 
     this.set('onDirectionsChanged', () => this.set('directionsChanged', true));
 
     this.set('addWaypoint', false);
 
-    const directionsChanged = () => this.get('directionsChanged');
+    let directionsChanged = () => this.get('directionsChanged');
     await waitUntil(directionsChanged, { timeout: 10000 });
 
-    const request = publicAPI.directions[0].directions.request;
+    let request = components.directions[0].directions.request;
 
     assert.equal(request.waypoints.length, 0);
   });
 });
-


### PR DESCRIPTION
* Cleanly expose parts of map components using proxies and getters.
* Make generating the public API much cleaner internally.
* Consistently return the public API in actions.