### PR TITLE
Refactor internals – 🎬 2 

### DIFF
--- a/addon/components/g-map.js
+++ b/addon/components/g-map.js
@@ -19,7 +19,7 @@ const GMapAPI = {
   components: 'components',
   actions: {
     update: '_updateMap',
-    trigger: 'trigger',
+    trigger: '_trigger',
   }
 };
 
@@ -184,8 +184,8 @@ export default Component.extend(ProcessOptions, RegisterEvents, {
    * @param {String} event Event name
    * @return
    */
-  _trigger(event) {
-    google.maps.event.trigger(get(this, 'map'), event);
+  _trigger(...args) {
+    google.maps.event.trigger(get(this, 'map'), ...args);
   },
 
   _registerCanvas(canvas, isCustomCanvas = false) {

--- a/addon/components/g-map/autocomplete.js
+++ b/addon/components/g-map/autocomplete.js
@@ -17,6 +17,14 @@ export default MapComponent.extend({
   _type: 'autocomplete',
   _ignoredAttrs: ['onSearch'],
 
+  init() {
+    this._super(...arguments);
+
+    this.publicAPI.reopen({
+      place: 'place'
+    });
+  },
+
   _addComponent() {
     let map = get(this, 'map');
 
@@ -38,10 +46,10 @@ export default MapComponent.extend({
   },
 
   _onSearch() {
-    const place = this.mapComponent.getPlace();
-    const map = get(this, 'map');
-    if (place.geometry) {
-      tryInvoke(this, 'onSearch', [{ place, map }]);
+    this.place = this.mapComponent.getPlace();
+
+    if (this.place.geometry) {
+      tryInvoke(this, 'onSearch', [this.publicAPI]);
     }
   }
 });

--- a/addon/components/g-map/circle.js
+++ b/addon/components/g-map/circle.js
@@ -15,7 +15,6 @@ export default Marker.extend({
   _requiredOptions: ['center', 'radius'],
 
   radius: 500,
-
   center: reads('position'),
 
   _addComponent() {

--- a/addon/components/g-map/info-window.js
+++ b/addon/components/g-map/info-window.js
@@ -26,6 +26,7 @@ export default MapComponent.extend({
 
   init() {
     this._super(...arguments);
+
     if (!get(this, 'target')) {
       this._requiredOptions = this._requiredOptions.concat(['position']);
     }
@@ -55,11 +56,14 @@ export default MapComponent.extend({
 
   _addComponent() {
     this._prepareContent();
+
     let options = get(this, '_options');
     delete options.map;
+
     if (!get(this, 'isOpen')) {
       delete options.content;
     }
+
     set(this, 'mapComponent', new google.maps.InfoWindow(options));
   },
 
@@ -67,20 +71,24 @@ export default MapComponent.extend({
     if (get(this, 'isOpen')) {
       this.open();
     }
+
     this._super(...arguments);
   },
 
   _updateComponent() {
     let options = get(this, '_options');
+
     if (!get(this, 'isOpen')) {
       delete options.content;
     }
+
     this.mapComponent.setOptions(options);
   },
 
   _prepareContent() {
     if (!get(this, 'content')) {
-      const content = document.createElement('div');
+      let content = document.createElement('div');
+
       set(this, '_targetPane', content);
       set(this, 'content', content);
     }
@@ -91,6 +99,7 @@ export default MapComponent.extend({
       google.maps.event.addListenerOnce(this.mapComponent, 'closeclick', () => {
         set(this, 'isOpen', false);
       });
+
       this.mapComponent.open(get(this, 'map'), get(this, 'target'));
     }
   },

--- a/addon/components/g-map/marker.js
+++ b/addon/components/g-map/marker.js
@@ -15,22 +15,12 @@ export default MapComponent.extend({
   layout,
   tagName: '',
 
-  _requiredOptions: ['position'],
-
   _type: 'marker',
+  _requiredOptions: ['position'],
 
   position,
 
   _addComponent() {
     set(this, 'mapComponent', new google.maps.Marker(get(this, '_options')));
-  },
-
-  /**
-   * @method getPosition
-   * @public
-   * @return {[google.maps.LatLng]}
-   */
-  getPosition() {
-    return this.mapComponent && this.mapComponent.getPosition();
   }
 });

--- a/addon/components/g-map/overlay.js
+++ b/addon/components/g-map/overlay.js
@@ -37,7 +37,7 @@ export default MapComponent.extend({
   }),
 
   _addComponent() {
-    const Overlay = new google.maps.OverlayView();
+    let Overlay = new google.maps.OverlayView();
 
     return new Promise((resolve) => {
       Overlay.onAdd = () => this.add();

--- a/addon/components/g-map/route.js
+++ b/addon/components/g-map/route.js
@@ -19,10 +19,12 @@ export default MapComponent.extend({
   _requiredOptions: ['directions'],
 
   _addComponent() {
-    const options = get(this, '_options');
+    let options = get(this, '_options');
+
     if (!options.directions) {
       return reject();
     }
+
     set(this, 'mapComponent', new google.maps.DirectionsRenderer(options));
   }
 });

--- a/addon/components/g-map/waypoint.js
+++ b/addon/components/g-map/waypoint.js
@@ -19,11 +19,13 @@ export default Component.extend(ProcessOptions, {
 
   didReceiveAttrs() {
     this._super(...arguments);
+
     this._registerWaypoint(get(this, '_options'));
   },
 
   willDestroyElement() {
     this._super(...arguments);
+
     this._unregisterWaypoint(get(this, '_options'));
   }
 });


### PR DESCRIPTION
* Correctly expose '_trigger' method and allow passing arbitrary
  arguments.
* Expose `place` in autocomplete.
* Remove usage of `const`.
* Add assertions to base map-component.
* Remove unused `getPosition` method from marker component.
* Cleanup options processing.
* Collect extracted event names in `_eventAttrs`. Use this array to
  filter out attrs when processing options.
* Ensure `events` is an object, not an array of event names.
* Allow registering events using both an `events` hash and by passing
attributes.