### PR TITLE
Update docs to reflect new tree-shaking item needed

### DIFF
--- a/tests/dummy/app/templates/snippets/ember-cli-build.js
+++ b/tests/dummy/app/templates/snippets/ember-cli-build.js
@@ -3,7 +3,7 @@ const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 module.exports = function(defaults) {
   let app = new EmberApp(defaults, {
     'ember-google-maps': {
-      only: ['marker', 'info-window']
+      only: ['-private-api/addon-factory', 'marker', 'info-window']
       // exclude: ['overlay']
     }
   });


### PR DESCRIPTION
Unless I'm much mistaken, tree-shaking no longer works unless this additional item is also added since the plugin setup was added ...