### PR TITLE
Move ember-concurrency to dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "chalk": "^2.3.1",
     "ember-cli-babel": "^6.14.1",
     "ember-cli-htmlbars": "^2.0.1",
+    "ember-concurrency": "^0.8.19",
     "handlebars": "^4.0.11",
     "strip-indent": "^2.0.0"
   },
@@ -68,7 +69,6 @@
     "ember-cli-uglify": "^2.0.0",
     "ember-code-snippet": "^2.2.1",
     "ember-composable-helpers": "^2.0.3",
-    "ember-concurrency": "^0.8.19",
     "ember-disable-prototype-extensions": "^1.1.2",
     "ember-export-application-global": "^2.0.0",
     "ember-google-maps-sample-addon": "sandydoo/ember-google-maps-sample-addon",


### PR DESCRIPTION
Seems that 855df068af6b40fc8af2e68ce20368487dbc3733 broke the package, using the latest versions ends up with:

```
Uncaught Error: Could not find module `ember-concurrency` imported from `ember-google-maps/components/g-map`
```

I've moved the `ember-concurrency` package from `devDependencies` to `dependencies` since it currently is a runtime requirement of `ember-google-maps`. This fixes the issue.