### PR TITLE
Bumped ember-google-maps-sample-addon to fix tests locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "ember-composable-helpers": "^2.0.3",
     "ember-disable-prototype-extensions": "^1.1.2",
     "ember-export-application-global": "^2.0.0",
-    "ember-google-maps-sample-addon": "sandydoo/ember-google-maps-sample-addon",
+    "ember-google-maps-sample-addon": "sandydoo/ember-google-maps-sample-addon#912b087510cecd02324c804d100da86486b12b80",
     "ember-load-initializers": "^1.1.0",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-resolver": "^4.5.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2719,9 +2719,9 @@ ember-export-application-global@^2.0.0:
   dependencies:
     ember-cli-babel "^6.0.0-beta.7"
 
-ember-google-maps-sample-addon@sandydoo/ember-google-maps-sample-addon:
+ember-google-maps-sample-addon@sandydoo/ember-google-maps-sample-addon#912b087510cecd02324c804d100da86486b12b80:
   version "0.0.0"
-  resolved "https://codeload.github.com/sandydoo/ember-google-maps-sample-addon/tar.gz/f9294766870d1673e68e1076a636ef525d9d1c75"
+  resolved "https://codeload.github.com/sandydoo/ember-google-maps-sample-addon/tar.gz/912b087510cecd02324c804d100da86486b12b80"
   dependencies:
     ember-cli-babel "^6.6.0"
     ember-cli-htmlbars "^2.0.1"


### PR DESCRIPTION
This wasn't caught in tests on Travis as the yarn lock file is ignored. And I'm assuming it wasn't caught on your machine because you'd done an `npm link` / `yarn link`? 😄 