### PR TITLE
Add a few defensive guards against set on destroyed object errors

### DIFF
--- a/addon/components/g-map/overlay.js
+++ b/addon/components/g-map/overlay.js
@@ -40,6 +40,7 @@ export default MapComponent.extend({
     return new Promise((resolve) => {
       Overlay.onAdd = () => join(this, 'add');
       Overlay.draw = () => schedule('render', () => {
+        if (this.isDestroyed) { return; }
         this._initialDraw();
         resolve();
       });
@@ -63,6 +64,7 @@ export default MapComponent.extend({
   },
 
   add() {
+    if (this.isDestroyed) { return; }
     let panes = this.mapComponent.getPanes();
     set(this, '_targetPane', get(panes, this.paneName));
   },


### PR DESCRIPTION
On a client project I'm working on, I was using the overlay component in some acceptance tests as I built things out (and we were using api keys in the test environment). We won't be doing that long-term, but in certain scenarios I was triggering `set on destroyed object` errors as seen below:
![screen shot 2018-08-08 at 12 41 49 pm](https://user-images.githubusercontent.com/802505/43857480-a878d332-9b08-11e8-8793-aa3a376cd588.png)

I couldn't replicate the issue easily in the test suite for this addon (though I got it to do it occasionally), so it's possible it occurs more when using "classic" test helpers as my client is. But I thought I should send this in to see if you want to merge it.

Seems unlikely that in daily use this issue would be hit that often. But it's technically a bug ... 😄  

If you've got ideas on better ways to replicate the issue, I'm happy to add some tests here ...