### PR TITLE
Add finer grained control over de-registration of a component from the publicAPI proxy

### DIFF
--- a/addon/components/g-map/map-component.js
+++ b/addon/components/g-map/map-component.js
@@ -62,6 +62,8 @@ const MapComponent = Component.extend(ProcessOptions, RegisterEvents, {
 
     tryInvoke(this.mapComponent, 'setMap', [null]);
 
+    this.publicAPI.remove(this);
+
     this._internalAPI._unregisterComponent(this._registrationType, this.publicAPI);
   },
 

--- a/addon/utils/public-api.js
+++ b/addon/utils/public-api.js
@@ -26,10 +26,6 @@ export default class PublicAPI {
   constructor(instance, schema) {
     proxy.set(this, instance);
 
-    instance.on('willDestroyElement', () => {
-      proxy.set(this, null);
-    });
-
     this.defineProxyProperties(schema);
   }
 
@@ -64,6 +60,10 @@ export default class PublicAPI {
 
       Object.defineProperty(target, prop, descriptor);
     });
+  }
+
+  remove() {
+    proxy.set(this, null);
   }
 
   reopen(schema) {


### PR DESCRIPTION
Fixes #39 . By making this change, we give addon authors a chance to interact with the map and do any needed tear down prior to tearing down the component registration with our publicAPI proxy while still using exclusively our `publicAPI`. A `map` property *does* currently exist on the `MapComponent` and children, but our naming implies that it might not in the future.

@sandydoo I'm happy to add some tests here if we want (doing that using an in-repo addon starts looking quite appealing 😉 ), but wanted to push this up to get your input on it before working up the tests.