### PR TITLE
Add ability to specify a class name for the control component

### DIFF
--- a/addon/components/g-map/control.js
+++ b/addon/components/g-map/control.js
@@ -10,6 +10,7 @@ import { get, set } from '@ember/object';
  */
 export default MapComponent.extend({
   layout,
+  class: undefined,
   tagName: 'div',
 
   _type: 'control',
@@ -18,6 +19,10 @@ export default MapComponent.extend({
   _addComponent() {
     let _elementDestination = set(this, '_elementDestination', document.createElement('div'));
     let map = get(this, 'map');
+
+    if (get(this, 'class')) {
+      _elementDestination.classList.add(get(this, 'class'));
+    }
 
     let controlPosition = google.maps.ControlPosition[get(this, 'position')];
     map.controls[controlPosition].push(_elementDestination);

--- a/tests/integration/components/g-map/control-test.js
+++ b/tests/integration/components/g-map/control-test.js
@@ -29,4 +29,17 @@ module('Integration | Component | g map/control', function(hooks) {
     let mapControls = map.controls[google.maps.ControlPosition.TOP_CENTER];
     assert.equal(controls[0].mapComponent, mapControls.getAt(0), 'control rendered in correct position');
   });
+
+  test('it renders a control with a class value', async function(assert) {
+    await render(hbs`
+      {{#g-map lat=lat lng=lng zoom=12 as |g|}}
+        {{#g.control position="TOP_CENTER" class="custom-control-holder"}}
+          <div id="custom-control"></div>
+        {{/g.control}}
+      {{/g-map}}
+    `);
+
+    let control = await waitFor('.custom-control-holder');
+    assert.ok(control, 'control rendered');
+  });
 });


### PR DESCRIPTION
In certain cases where your designer has ambitious designs, it's quite helpful to be able to specify a class name on a control:

```hbs
{{#g-map lat="" lng="" as |g|}}
  {{g.control position="TOP_CENTER" className="sidebar"}}
{{/g-map}}
```

I opted for `className` instead of `class` to avoid confusion when used in conjunction with angle bracket syntax down the road. At the moment, I don't believe the syntax below works (I don't believe yielded values can be called with dot syntax) but if they can in the future, we want to avoid the headaches below:

```hbs
<!-- sets the class on the div element rendered by the template -->
<G.Control class="sidebar">

<!-- sets the class on the div element we create in the control -->
<G.Control @class="sidebar">

<!-- opting for @className makes it clearer that we aren't setting an HTML property -->
<G.Control @className="sidebar">
```