### PR TITLE
allow user to add inner container class names to overlay

### DIFF
--- a/addon/components/g-map/overlay.js
+++ b/addon/components/g-map/overlay.js
@@ -28,6 +28,7 @@ export default MapComponent.extend({
   _targetPane: null,
   _eventTarget: reads('content'),
 
+  innerContainerClassNames: undefined,
   innerContainerStyle: htmlSafe('transform: translateX(-50%) translateY(-100%);'),
 
   _contentId: computed(function() {

--- a/addon/templates/components/g-map/overlay.hbs
+++ b/addon/templates/components/g-map/overlay.hbs
@@ -1,6 +1,6 @@
 {{#if _targetPane}}
   {{#-in-element _targetPane}}
-    <div id={{_contentId}}>
+    <div id={{_contentId}} class={{innerContainerClassNames}}>
       {{#_private-api/detect-render
         style=innerContainerStyle
         didRender=(action _updateComponent)}}

--- a/tests/integration/components/g-map/overlay-test.js
+++ b/tests/integration/components/g-map/overlay-test.js
@@ -28,7 +28,7 @@ module('Integration | Component | g map/overlay', function(hooks) {
   test('it renders a custom overlay', async function(assert) {
     await render(hbs`
       {{#g-map lat=lat lng=lng zoom=12 as |g|}}
-        {{#g.overlay lat=lat lng=lng}}
+        {{#g.overlay innerContainerClassNames="pastafano" lat=lat lng=lng}}
           <div id="custom-overlay"></div>
         {{/g.overlay}}
       {{/g-map}}
@@ -43,5 +43,7 @@ module('Integration | Component | g map/overlay', function(hooks) {
     assert.ok(overlay, 'overlay rendered');
 
     assert.ok(mapDiv.contains(overlay), 'overlay is child of map node');
+
+    assert.ok(overlay.parentElement.parentElement.getAttribute('class').includes('pastafano'));
   });
 });


### PR DESCRIPTION
attach class names to overlay's inner container element.

```
{{#g.overlay innerContainerClassNames="pastafano" lat=lat lng=lng}}
{{/g.overlay}}
```