### PR TITLE
fix: Splat html attributes on the canvas div element

### DIFF
--- a/addon/components/g-map.js
+++ b/addon/components/g-map.js
@@ -191,11 +191,7 @@ export default Component.extend(ProcessOptions, RegisterEvents, {
   _registerCanvas(canvas) {
     set(this, 'canvas', canvas);
 
-    this._notifyCanvasHasRendered();
-  },
-
-  _notifyCanvasHasRendered() {
-    this._canvasIsRendering.resolve(this.canvas);
+    this._canvasIsRendering.resolve(canvas);
   },
 
   _endInitialRender() {

--- a/addon/components/g-map/canvas.js
+++ b/addon/components/g-map/canvas.js
@@ -1,6 +1,7 @@
 import Component from '@ember/component';
 import { computed, get } from '@ember/object';
 import { bool } from '@ember/object/computed';
+import { scheduleOnce } from '@ember/runloop';
 
 
 /**
@@ -35,9 +36,13 @@ export default Component.extend({
 
     if (this._customCanvas) { return; }
 
-    let id = get(this, 'id');
-    let canvas = document.getElementById(id);
+    // TODO: Remove in Octane version. Splattributes somehow affect the
+    // rendering loop, so this is necessary for 2.18.
+    scheduleOnce('render', this, function() {
+      let id = get(this, 'id');
+      let canvas = document.getElementById(id);
 
-    this._internalAPI._registerCanvas(canvas);
+      this._internalAPI._registerCanvas(canvas);
+    });
   }
 });

--- a/addon/templates/components/g-map/canvas.hbs
+++ b/addon/templates/components/g-map/canvas.hbs
@@ -2,6 +2,6 @@
   {{_customCanvas}}
 {{else}}
   {{#if this._shouldRenderDefaultCanvas}}
-    <div id={{id}} class={{computedClasses}} style={{style}}>{{yield}}</div>
+    <div id={{id}} class={{computedClasses}} style={{style}} ...attributes>{{yield}}</div>
   {{/if}}
 {{/if}}

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "broccoli-merge-trees": "^3.0.0",
     "camelcase": "^5.0.0",
     "chalk": "^2.3.1",
+    "ember-angle-bracket-invocation-polyfill": "^2.0.2",
     "ember-cli-babel": "^7.7.3",
     "ember-cli-htmlbars": "^3.0.1",
     "ember-concurrency": "1.0.0",

--- a/tests/integration/components/g-map/canvas-test.js
+++ b/tests/integration/components/g-map/canvas-test.js
@@ -10,11 +10,31 @@ module('Integration | Component | g map/canvas', function(hooks) {
   setupMapTest(hooks);
   setupLocations(hooks);
 
-  test('it renders a canvas div', async function(assert) {
-    this._internalAPI = { _registerCanvas: () => {} };
-
-    await render(hbs`{{g-map/canvas _internalAPI=_internalAPI}}`);
+  test('it renders a default canvas div', async function(assert) {
+    await render(hbs`
+      {{g-map lat=lat lng=lng zoom=12}}
+    `);
 
     assert.ok(find('.ember-google-map'), 'canvas rendered');
+  });
+
+  test('it renders a custom canvas div', async function(assert) {
+    await render(hbs`
+      {{#g-map lat=lat lng=lng zoom=12 as |g|}}
+        {{g.canvas class="custom-class"}}
+      {{/g-map}}
+    `);
+
+    assert.ok(find('.custom-class'), 'custom canvas rendered');
+  });
+
+  test('it renders a custom canvas div with splatted classes', async function(assert) {
+    await render(hbs`
+      {{#g-map lat=lat lng=lng zoom=12 as |g|}}
+        <g.canvas class="custom-class" />
+      {{/g-map}}
+    `);
+
+    assert.ok(find('.custom-class'), 'custom angle-bracket canvas rendered');
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3350,6 +3350,16 @@ electron-to-chromium@^1.3.191, electron-to-chromium@^1.3.47:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.201.tgz#b516e941baf01a7cf8abd33af537a39e1e0096db"
   integrity sha512-aCTPIfY1Jvuam5b6vuWRjt1F8i4kY7zX0Qtpu5SNd6l1zjuxU9fDNpbM4o6+oJsra+TMD2o7D20GnkSIgpTr9w==
 
+ember-angle-bracket-invocation-polyfill@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/ember-angle-bracket-invocation-polyfill/-/ember-angle-bracket-invocation-polyfill-2.0.2.tgz#117ab5238305f11046a2eb3a5bc026c98d2cf5c1"
+  integrity sha512-HkG0xyTHtAhWVjU0Q5V/i4xe4FRvNIOaiUEgIvN815F3TIUboV/J0xhYgivm0uDZp9lAYUVF+U5PI1sCnlC3Og==
+  dependencies:
+    ember-cli-babel "^6.17.0"
+    ember-cli-version-checker "^2.1.2"
+    ember-compatibility-helpers "^1.0.2"
+    silent-error "^1.1.1"
+
 ember-assign-polyfill@^2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/ember-assign-polyfill/-/ember-assign-polyfill-2.6.0.tgz#07847e3357ee35b33f886a0b5fbec6873f6860eb"
@@ -3363,7 +3373,7 @@ ember-cli-babel-plugin-helpers@^1.1.0:
   resolved "https://registry.yarnpkg.com/ember-cli-babel-plugin-helpers/-/ember-cli-babel-plugin-helpers-1.1.0.tgz#de3baedd093163b6c2461f95964888c1676325ac"
   integrity sha512-Zr4my8Xn+CzO0gIuFNXji0eTRml5AxZUTDQz/wsNJ5AJAtyFWCY4QtKdoELNNbiCVGt1lq5yLiwTm4scGKu6xA==
 
-ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.10.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.8.2, ember-cli-babel@^6.9.0:
+ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.10.0, ember-cli-babel@^6.17.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.8.2, ember-cli-babel@^6.9.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz#3f6435fd275172edeff2b634ee7b29ce74318957"
   integrity sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==
@@ -3896,7 +3906,7 @@ ember-code-snippet@2.4.1:
     es6-promise "^1.0.0"
     glob "^7.1.3"
 
-ember-compatibility-helpers@^1.2.0:
+ember-compatibility-helpers@^1.0.2, ember-compatibility-helpers@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-1.2.0.tgz#feee16c5e9ef1b1f1e53903b241740ad4b01097e"
   integrity sha512-pUW4MzJdcaQtwGsErYmitFRs0rlCYBAnunVzlFFUBr4xhjlCjgHJo0b53gFnhTgenNM3d3/NqLarzRhDTjXRTg==


### PR DESCRIPTION
I noticed that [this commit](https://github.com/sandydoo/ember-google-maps/commit/86c6dcfb726636187ad033781a4d268b2d089989) doesn't work when using AngleBrackets. `this.class` will be undefined if you pass classes like this
```handlebars
...
<g.canvas class="test" />
...
```

This makes sure that classes are properly applied to the div when using AngleBrackets invocation. Using splattributes shouldn't be a problem since the Readme mentions Ember 3.4+, right?