### PR TITLE
Guard this.content.style in overlay with isPresent helper

### DIFF
--- a/addon/components/g-map/overlay.js
+++ b/addon/components/g-map/overlay.js
@@ -7,6 +7,7 @@ import { bind, once, scheduleOnce } from '@ember/runloop';
 import { guidFor } from '@ember/object/internals';
 import { assert, warn } from '@ember/debug';
 import { defer, resolve } from 'rsvp';
+import { isPresent } from '@ember/utils';
 
 
 const { READY } = MapComponentLifecycleEnum;
@@ -116,14 +117,17 @@ https://ember-google-maps.sandydoo.me/docs/overlays/`,
         point = overlayProjection.fromLatLngToDivPixel(position),
         zIndex = get(this, 'zIndex');
 
-    this.content.style.cssText = `
-      position: absolute;
-      left: 0;
-      top: 0;
-      height: 0;
-      z-index: ${zIndex};
-      transform: translateX(${point.x}px) translateY(${point.y}px);
-    `;
+    let { content } = this;
+    if (isPresent(content)) {
+      content.style.cssText = `
+        position: absolute;
+        left: 0;
+        top: 0;
+        height: 0;
+        z-index: ${zIndex};
+        transform: translateX(${point.x}px) translateY(${point.y}px);
+      `;
+    }
   },
 
   fetchOverlayContent(id) {


### PR DESCRIPTION
We're seeing a lot of rollbar errors triggered since updating to ember 3.17. This particular block 

```
TypeError: Cannot read property 'style' of null (Most recent call first)
File addon-tree-output/ember-google-maps/components/g-map/overlay.js line 121 col 1 in draw
this.content.style.cssText = "\n position: absolute;\n left: 0;\n top: 0;\n ...
```

I've added an isPresent guard on `this.content`. Works the same as before. Let me know if I can make any other changes. 