### PR TITLE
Add support for Cloud-based Map Styling

### DIFF
--- a/index.js
+++ b/index.js
@@ -285,6 +285,7 @@ module.exports = {
       protocol,
       region,
       version,
+      mapId,
     } = config;
 
     if (!key && !client) {
@@ -330,6 +331,10 @@ module.exports = {
 
     if (key) {
       params.push('key=' + encodeURIComponent(key));
+    }
+
+    if (mapId) {
+      params.push('map_ids=' + encodeURIComponent(mapId));
     }
 
     if (protocol) {

--- a/index.js
+++ b/index.js
@@ -285,7 +285,7 @@ module.exports = {
       protocol,
       region,
       version,
-      mapId,
+      mapIds,
     } = config;
 
     if (!key && !client) {
@@ -333,8 +333,8 @@ module.exports = {
       params.push('key=' + encodeURIComponent(key));
     }
 
-    if (mapId) {
-      params.push('map_ids=' + encodeURIComponent(mapId));
+    if (mapIds) {
+      params.push('map_ids=' + encodeURIComponent(mapIds));
     }
 
     if (protocol) {


### PR DESCRIPTION
This PR adds support for cloud based map stylings (https://developers.google.com/maps/documentation/javascript/cloud-based-map-styling)

Adding the `mapId` to the url at runtime seems wrong in this particular case and can result in flickering of different styles. 