### PR TITLE
Remove `onComponentsLoad` hook

### DIFF
--- a/addon/components/g-map.js
+++ b/addon/components/g-map.js
@@ -49,12 +49,6 @@ export default class GMap extends MapComponent {
     google.maps.event.addListenerOnce(map, 'idle', () => {
       // Compatibility: You should use `idle` directly instead of this.
       this.events.onLoad?.(this.publicAPI);
-
-      // Compatibility: We don’t really track this anymore and I don’t think
-      // it’s that useful in Octane. You should either use `idle` or use a
-      // specific component event for things that happen asynchronously, for
-      // example, `onDirectionsChanged`.
-      this.events.onComponentsLoad?.(this.publicAPI);
     });
 
     return map;

--- a/docs/app/templates/docs/components.hbs
+++ b/docs/app/templates/docs/components.hbs
@@ -32,12 +32,6 @@
       <p>Since the Ember components are just light wrappers for the actual Google map classes, you may need access to the instances of the map components. Each map component automatically registers with the parent map component – <LinkTo @route="docs.map"><var>g-map</var></LinkTo>. The parent map then provides a <var>publicAPI</var>. This object contains the the map component instances that are accessible by the plural of the component name. Using the <var>onLoad</var> action, you can get access to this object once the map loads.</p>
 
       <CodeSnippet @name="map-public-api.js" />
-
-      <CodeSnippet @name="map-on-load.hbs" />
-
-      <CodeSnippet @name="handle-on-load.js" />
-
-      <p>Some components may take some time to initialise and render on the map. You can provide an <var>onComponentsLoad</var> action to the map that will be called once all the components have been registered with the map.</p>
     </section>
     <p>Learn more about what you can do with these components in the next section.</p>
     <LinkToNext @nextPage={{this.nextPage}} />

--- a/docs/code-snippets/handle-on-load.js
+++ b/docs/code-snippets/handle-on-load.js
@@ -1,9 +1,0 @@
-import Controller from '@ember/controller';
-import { action } from '@ember/object';
-
-export default class extends Controller {
-  @action
-  onLoad({ map, publicAPI }) {
-    // Do something. Save a copy of the map instance and publicAPI.
-  }
-}

--- a/docs/code-snippets/map-on-load.hbs
+++ b/docs/code-snippets/map-on-load.hbs
@@ -1,4 +1,0 @@
-<GMap
-  @lat={{this.london.lat}}
-  @lng={{this.london.lng}}
-  @onLoad={{this.onLoad}} />

--- a/docs/code-snippets/map-public-api.js
+++ b/docs/code-snippets/map-public-api.js
@@ -1,7 +1,9 @@
 const publicAPI = {
-  markers: [],
-  circles: [],
-  polylines: [],
-  infoWindows: [],
-  // ...
-}
+  components: {
+    markers: [],
+    circles: [],
+    polylines: [],
+    infoWindows: [],
+    // ...
+  },
+};

--- a/tests/integration/components/g-map-test.js
+++ b/tests/integration/components/g-map-test.js
@@ -116,29 +116,6 @@ module('Integration | Component | g map', function (hooks) {
     map.setZoom(10);
   });
 
-  test('it calls the `onComponentsLoad` hook when all the components are ready', async function (assert) {
-    assert.expect(2);
-
-    this.onComponentsLoad = ({ components }) => {
-      assert.ok('onComponentsLoad called');
-
-      let marker = components.markers?.[0]?.mapComponent?.getMap();
-
-      assert.ok(marker, 'The component is rendered on the map');
-    };
-
-    await render(hbs`
-      <GMap
-        @lat={{this.lat}}
-        @lng={{this.lng}}
-        @onComponentsLoad={{this.onComponentsLoad}} as |g|>
-
-        <g.marker @lat={{this.lat}} @lng={{this.lng}} />
-
-      </GMap>
-    `);
-  });
-
   test('it passes attributes to the default canvas', async function (assert) {
     await render(hbs`
       <GMap @lat={{this.lat}} @lng={{this.lng}} class="attributes-test" />


### PR DESCRIPTION
Currently, it doesn’t even work properly because we don’t do the
expensive tracking anymore. I reckon it’s not even a necessary feature:
you should use more specific `on*` events on the components you care
about.