### PR TITLE
Add `onceOn` events that fire only once

### DIFF
--- a/docs/app/templates/docs/complex-ui.hbs
+++ b/docs/app/templates/docs/complex-ui.hbs
@@ -18,7 +18,7 @@
       <ol>
         <li>We set the center of the map and the zoom level in the first line.</li>
         <li>We then set a bunch of map options: we modify the look of the map tiles with <var>styles</var>, disable the scroll wheel to force the feed to scroll down instead, and mess around with the map controls to achieve a minimalist look.</li>
-        <li>We use <var>onLoad</var> and <var>onBoundsChanged</var> events to fetch the current map bounds. We use these bounds to filter the random array of markers on the map. This filtered array is called <var>boundedLondonLocations</var>. This simulates loading external data when panning or zooming the map.</li>
+        <li>We use <var>onceOnIdle</var> and <var>onBoundsChanged</var> events to fetch the current map bounds. We use these bounds to filter the random array of markers on the map. This filtered array is called <var>boundedLondonLocations</var>. This simulates loading external data when panning or zooming the map.</li>
         <li>We use the <var>{{"{{each}}"}}</var> helper to loop over the locations and display an <var>overlay</var> with custom content at the given location coordinates. Inside the overlay, we render a custom, styled tooltip <var>div</var>, containing the price of the rental.</li>
         <li>The <var>onMouseover</var> and <var>onMouseleave</var> events modify the <var>active</var> property on the rental, which lets us animate the tooltip and the card in the feed. Finally, the <var>onClick</var> event receives the clicked rental and scrolls to its card in the feed.</li>
       </ol>

--- a/docs/app/templates/docs/components.hbs
+++ b/docs/app/templates/docs/components.hbs
@@ -29,9 +29,13 @@
     <section>
       <h5>Accessing component instances</h5>
 
-      <p>Since the Ember components are just light wrappers for the actual Google map classes, you may need access to the instances of the map components. Each map component automatically registers with the parent map component – <LinkTo @route="docs.map"><var>g-map</var></LinkTo>. The parent map then provides a <var>publicAPI</var>. This object contains the the map component instances that are accessible by the plural of the component name. Using the <var>onLoad</var> action, you can get access to this object once the map loads.</p>
+      <p>Since the Ember components are just light wrappers for the actual Google map classes, you may need access to the instances of the map components. Each map component automatically registers with the parent map component – <LinkTo @route="docs.map"><var>g-map</var></LinkTo>. The parent map then provides a <var>publicAPI</var>. This object contains the the map component instances that are accessible by the plural of the component name. Using the <var>onceOnIdle</var> action, you can get access to this object once the map loads.</p>
 
       <CodeSnippet @name="map-public-api.js" />
+
+      <CodeSnippet @name="map-once-on-idle.hbs" />
+
+      <CodeSnippet @name="handle-once-on-idle.js" />
     </section>
     <p>Learn more about what you can do with these components in the next section.</p>
     <LinkToNext @nextPage={{this.nextPage}} />

--- a/docs/app/templates/docs/events.hbs
+++ b/docs/app/templates/docs/events.hbs
@@ -75,6 +75,7 @@
       @zoom={{12}}
       @styles={{this.primaryMapStyle}}
       class="ember-google-map-responsive"
+      @onceOnIdle={{fn this.flashMessage "The map is here. Well, give it a wave!"}}
       @onBoundsChanged={{fn this.flashMessageThrottle "The bounds have changed!"}}
       @onClick={{fn this.flashMessage "You clicked the map!"}}
       @onDblclick={{fn this.flashMessage "Ooh, a double click!!"}}

--- a/docs/app/templates/docs/map.hbs
+++ b/docs/app/templates/docs/map.hbs
@@ -24,7 +24,7 @@
     <section>
       <h5 id="map-instance">Accessing the map instance</h5>
 
-      <p>If you need access the map instance – to call <var>panTo</var> for example – you can use the <var>onLoad</var> hook. It will return the map instance once the map has been initialised.</p>
+      <p>If you need access the map instance – to call <var>panTo</var> for example – you can use the <var>onceOnIdle</var> hook. It will return the map instance once the map has been initialised.</p>
     </section>
 
     <LinkToNext @nextPage={{this.nextPage}} />

--- a/docs/app/templates/examples/sweet-rentals.hbs
+++ b/docs/app/templates/examples/sweet-rentals.hbs
@@ -30,7 +30,7 @@
       @zoomControlOptions={{hash
         position=this.google.maps.ControlPosition.TOP_LEFT}}
       @fullscreenControl={{true}}
-      @onLoad={{this.saveBounds}}
+      @onceOnIdle={{this.saveBounds}}
       @onBoundsChanged={{this.saveBounds}} as |g|>
 
       {{#each this.filteredRentals key="id" as |rental index|}}

--- a/docs/code-snippets/handle-once-on-idle.js
+++ b/docs/code-snippets/handle-once-on-idle.js
@@ -1,0 +1,9 @@
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+
+export default class extends Controller {
+  @action
+  onLoad({ map, components }) {
+    // Do something with the map
+  }
+}

--- a/docs/code-snippets/map-once-on-idle.hbs
+++ b/docs/code-snippets/map-once-on-idle.hbs
@@ -1,0 +1,4 @@
+<GMap
+  @lat={{this.london.lat}}
+  @lng={{this.london.lng}}
+  @onceOnIdle={{this.onLoad}} />

--- a/docs/code-snippets/sweet-rentals-map.hbs
+++ b/docs/code-snippets/sweet-rentals-map.hbs
@@ -10,7 +10,7 @@
   @zoomControlOptions={{hash
     position=this.google.maps.ControlPosition.TOP_LEFT}}
   @fullscreenControl={{true}}
-  @onLoad={{this.saveBounds}}
+  @onceOnIdle={{this.saveBounds}}
   @onBoundsChanged={{this.saveBounds}}
   class="ember-google-map-cover" as |map|>
 

--- a/tests/integration/components/g-map-test.js
+++ b/tests/integration/components/g-map-test.js
@@ -85,6 +85,28 @@ module('Integration | Component | g map', function (hooks) {
     map.setZoom(10);
   });
 
+  test('it supports events that trigger only once', async function (assert) {
+    assert.expect(1);
+
+    this.onLoad = ({ eventName }) => {
+      assert.equal(eventName, 'idle', 'map loaded and idle');
+    };
+
+    await render(hbs`
+      <GMap
+        @lat={{this.lat}}
+        @lng={{this.lng}}
+        @zoom={{12}}
+        @onceOnIdle={{this.onLoad}} />
+    `);
+
+    let { map } = await this.waitForMap();
+
+    map.panBy(250, 250);
+
+    await this.waitForMap();
+  });
+
   test('it accepts both an events hash and individual attribute events', async function (assert) {
     assert.expect(2);
 


### PR DESCRIPTION
You can now register events that will trigger just once. This uses Google Maps’ `addListenerOnce`.

#### Examples

This can be used to replace the old `onLoad` event, which was a custom event provided by `ember-google-maps`.

Before:
```hbs
<GMap @lat="this.lat" @lng="this.lng" @onLoad={{this.onMapLoad}} />
```

After:
```hbs
<GMap @lat="this.lat" @lng="this.lng" @onceOnIdle={{this.onMapLoad}} />
```