### PR TITLE
Improve how we wait for the map in tests

### DIFF
--- a/addon/component-managers/map-component-manager.js
+++ b/addon/component-managers/map-component-manager.js
@@ -3,7 +3,9 @@ import { setOwner } from '@ember/application';
 import { inject as service } from '@ember/service';
 import { associateDestroyableChild, destroy } from '@ember/destroyable';
 import { assert } from '@ember/debug';
-import { waitFor } from '@ember/test-waiters';
+
+import { buildWaiter } from '@ember/test-waiters';
+let testWaiter = buildWaiter('ember-google-maps:map-component-waiter');
 
 import { OptionsAndEvents } from 'ember-google-maps/utils/options-and-events';
 import { setupEffect } from 'ember-google-maps/effects/tracking';
@@ -64,9 +66,10 @@ export class MapComponentManager {
     return component ?? {};
   }
 
-  @waitFor
   setupMapComponent(component) {
     assert('Implement new', component.new);
+
+    let token = testWaiter.beginAsync();
 
     let hasUpdate = typeof component.update === 'function';
 
@@ -86,6 +89,8 @@ export class MapComponentManager {
           component.update(mapComponent, component.options);
         }
 
+        testWaiter.endAsync(token);
+
         return trackThisInstead ?? mapComponent;
       });
     } else {
@@ -94,6 +99,8 @@ export class MapComponentManager {
 
         component.mapComponent = mapComponent;
 
+        testWaiter.endAsync(token);
+
         return mapComponent;
       });
     }
@@ -101,7 +108,6 @@ export class MapComponentManager {
     // Destroy effects when the component is destroyed.
     associateDestroyableChild(component, effect);
 
-    // Fix for @waitFor
-    return mapComponent ?? {};
+    return mapComponent;
   }
 }

--- a/addon/components/g-map.js
+++ b/addon/components/g-map.js
@@ -51,13 +51,6 @@ export default class GMap extends MapComponent {
       this.events.onLoad?.(this.publicAPI);
     });
 
-    return map;
-  }
-
-  update(map) {
-    map.setOptions(this.newOptions);
-
-    // Pause tests until map is in an idle state.
     if (DEBUG) {
       this.pauseTestForIdle(map);
     }
@@ -65,6 +58,17 @@ export default class GMap extends MapComponent {
     return map;
   }
 
+  update(map) {
+    map.setOptions(this.newOptions);
+
+    if (DEBUG) {
+      this.pauseTestForIdle(map);
+    }
+
+    return map;
+  }
+
+  // Pause tests until map is in an idle state.
   @waitFor
   async pauseTestForIdle(map) {
     await new Promise((resolve) => {


### PR DESCRIPTION
Let's set up the test waiters in the map component manager. This is a
good spot to add waiting for all the map components. On the map itself,
we additionally wait for the idle event.