### PR TITLE
Deprecate the `onLoad` event

### DIFF
--- a/build-tests/fixtures/treeshaking-test/tests/integration/shakedown-test.js
+++ b/build-tests/fixtures/treeshaking-test/tests/integration/shakedown-test.js
@@ -36,7 +36,8 @@ module('Integration | Treeshaking', function (hooks) {
 
     console.warn = (...messages) => {
       messages.forEach((message) => {
-        if (expectedError.test(message)) {
+        let messageText = message.text ?? message;
+        if (expectedError.test(messageText)) {
           assert.ok('missing component assertion thrown');
         }
 

--- a/tests/integration/components/g-map-test.js
+++ b/tests/integration/components/g-map-test.js
@@ -107,6 +107,38 @@ module('Integration | Component | g map', function (hooks) {
     await this.waitForMap();
   });
 
+  test('it deprecates the custom onLoad event', async function (assert) {
+    assert.expect(2);
+
+    let originalConsoleWarn = console.warn;
+
+    console.warn = (msg) => {
+      let msgText = msg.text ?? msg;
+
+      if (/The `onLoad` event has been deprecated/.test(msgText)) {
+        assert.ok(true, 'Using the onLoad event displays a deprecation notice');
+      } else {
+        originalConsoleWarn(msg);
+      }
+    };
+
+    this.onLoad = () => {
+      assert.ok(true, 'onLoad is still called');
+    };
+
+    await render(hbs`
+      <GMap
+        @lat={{this.lat}}
+        @lng={{this.lng}}
+        @zoom={{12}}
+        @onLoad={{this.onLoad}} />
+    `);
+
+    await this.waitForMap();
+
+    console.warn = originalConsoleWarn;
+  });
+
   test('it accepts both an events hash and individual attribute events', async function (assert) {
     assert.expect(2);
 


### PR DESCRIPTION
The custom `onLoad` event has been deprecated. You should replace it with `onceOnIdle`.

If you had the following:

```js
<GMap @lat={{this.lat}} @lng={{this.lng}} @onLoad={{this.didLoadMap}} />
```
Replace it with:
```js
<GMap @lat={{this.lat}} @lng={{this.lng}} @onceOnIdle={{this.didLoadMap}} />
```