### PR TITLE
Temporarily switch to a patched version of `tracked-maps-and-sets`

### DIFF
--- a/addon/components/g-map/directions.js
+++ b/addon/components/g-map/directions.js
@@ -4,7 +4,7 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { Promise, reject } from 'rsvp';
 import { didCancel, keepLatestTask } from 'ember-concurrency';
-import { TrackedSet } from 'tracked-maps-and-sets';
+import { TrackedSet } from '@sandydoo/tracked-maps-and-sets';
 import { waitFor } from '@ember/test-waiters';
 
 export function DirectionsAPI(source) {

--- a/docs/app/controllers/docs.js
+++ b/docs/app/controllers/docs.js
@@ -1,7 +1,7 @@
 import ApplicationController from './application';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
-import { TrackedMap } from 'tracked-maps-and-sets';
+import { TrackedMap } from '@sandydoo/tracked-maps-and-sets';
 import darkStyle from '../map-styles/dark';
 import lightStyle from '../map-styles/light';
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -85,7 +85,7 @@
     "qunit": "^2.14.1",
     "qunit-dom": "^1.6.0",
     "sass": "^1.23.7",
-    "tracked-maps-and-sets": "^2.2.1"
+    "@sandydoo/tracked-maps-and-sets": "^2.2.2"
   },
   "engines": {
     "node": "10.* || >= 12"

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -1420,6 +1420,15 @@
     "@nodelib/fs.scandir" "2.1.4"
     fastq "^1.6.0"
 
+"@sandydoo/tracked-maps-and-sets@^2.2.2":
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/@sandydoo/tracked-maps-and-sets/-/tracked-maps-and-sets-2.2.2.tgz#6c2b365618142f696b1e3a024c29f9081025528a"
+  integrity sha512-lnuf9fGvShbBxaX/ATHYi8tdADRFanxIWZGoJFsPdJbEpkXMWeMezVrq0DHUjwNvPcxTKKN3yACxmVEz8HvZkA==
+  dependencies:
+    "@glimmer/tracking" "^1.0.0"
+    ember-cli-babel "^7.26.5"
+    ember-compatibility-helpers "^1.2.4"
+
 "@simple-dom/document@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@simple-dom/document/-/document-1.4.0.tgz#af60855f957f284d436983798ef1006cca1a1678"
@@ -5072,10 +5081,43 @@ ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.6.0, ember-cli-babel@^6.9.0:
     ember-cli-version-checker "^2.1.2"
     semver "^5.5.0"
 
-ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.0, ember-cli-babel@^7.1.2, ember-cli-babel@^7.11.1, ember-cli-babel@^7.13.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.17.2, ember-cli-babel@^7.18.0, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.0, ember-cli-babel@^7.23.1, ember-cli-babel@^7.26.2, ember-cli-babel@^7.26.3, ember-cli-babel@^7.4.1, ember-cli-babel@^7.7.3:
+ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.0, ember-cli-babel@^7.1.2, ember-cli-babel@^7.11.1, ember-cli-babel@^7.13.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.18.0, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.0, ember-cli-babel@^7.23.1, ember-cli-babel@^7.26.2, ember-cli-babel@^7.26.3, ember-cli-babel@^7.4.1, ember-cli-babel@^7.7.3:
   version "7.26.3"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.26.3.tgz#e93ce7ec458208894d10844cf76e41cc06fdbeb6"
   integrity sha512-ZCs0g99d3kYaHs1+HT33oMY7/K+nLCAAv7dCLxsMzg7cQf55O6Pq4ZKnWEr3IHVs33xbJFnEb9prt1up36QVnw==
+  dependencies:
+    "@babel/core" "^7.12.0"
+    "@babel/helper-compilation-targets" "^7.12.0"
+    "@babel/plugin-proposal-class-properties" "^7.13.0"
+    "@babel/plugin-proposal-decorators" "^7.13.5"
+    "@babel/plugin-transform-modules-amd" "^7.13.0"
+    "@babel/plugin-transform-runtime" "^7.13.9"
+    "@babel/plugin-transform-typescript" "^7.13.0"
+    "@babel/polyfill" "^7.11.5"
+    "@babel/preset-env" "^7.12.0"
+    "@babel/runtime" "7.12.18"
+    amd-name-resolver "^1.3.1"
+    babel-plugin-debug-macros "^0.3.4"
+    babel-plugin-ember-data-packages-polyfill "^0.1.2"
+    babel-plugin-ember-modules-api-polyfill "^3.5.0"
+    babel-plugin-module-resolver "^3.2.0"
+    broccoli-babel-transpiler "^7.8.0"
+    broccoli-debug "^0.6.4"
+    broccoli-funnel "^2.0.2"
+    broccoli-source "^2.1.2"
+    clone "^2.1.2"
+    ember-cli-babel-plugin-helpers "^1.1.1"
+    ember-cli-version-checker "^4.1.0"
+    ensure-posix-path "^1.0.2"
+    fixturify-project "^1.10.0"
+    resolve-package-path "^3.1.0"
+    rimraf "^3.0.1"
+    semver "^5.5.0"
+
+ember-cli-babel@^7.26.5:
+  version "7.26.6"
+  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.26.6.tgz#322fbbd3baad9dd99e3276ff05bc6faef5e54b39"
+  integrity sha512-040svtfj2RC35j/WMwdWJFusZaXmNoytLAMyBDGLMSlRvznudTxZjGlPV6UupmtTBApy58cEF8Fq4a+COWoEmQ==
   dependencies:
     "@babel/core" "^7.12.0"
     "@babel/helper-compilation-targets" "^7.12.0"
@@ -5615,7 +5657,7 @@ ember-code-snippet@^3.0.0:
     es6-promise "^1.0.0"
     glob "^7.1.3"
 
-ember-compatibility-helpers@^1.1.2, ember-compatibility-helpers@^1.2.1:
+ember-compatibility-helpers@^1.1.2, ember-compatibility-helpers@^1.2.1, ember-compatibility-helpers@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-1.2.4.tgz#70e0fef7048969141626eed6006f3880df612cd1"
   integrity sha512-qjzQVtogyYJrSs6I4DuyCDwDCaj5JWBVNPoZDZBk8pt7caNoN0eBYRYJdin95QKaNMQODxTLPWaI4UUDQ1YWhg==
@@ -11837,14 +11879,6 @@ tr46@^2.0.2:
   integrity sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==
   dependencies:
     punycode "^2.1.1"
-
-tracked-maps-and-sets@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/tracked-maps-and-sets/-/tracked-maps-and-sets-2.2.1.tgz#323dd40540c561e8b0ffdec8bf129c68ec5025f9"
-  integrity sha512-XYrXh6L/GpGmVmG3KcN/qoDyi4FxHh8eZY/BA/RuoxynskV+GZSfwrX3R+5DR2CIkzkCx4zi4kkDRg1AMDfDhg==
-  dependencies:
-    "@glimmer/tracking" "^1.0.0"
-    ember-cli-babel "^7.17.2"
 
 tree-sync@^1.2.2:
   version "1.4.0"

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "test:build": "node build-tests/build-test"
   },
   "dependencies": {
+    "@sandydoo/tracked-maps-and-sets": "^2.2.2",
     "babel-plugin-ember-modules-api-polyfill": ">=3.5.0",
     "broccoli-debug": "^0.6.5",
     "broccoli-funnel": ">=2.0.0",
@@ -50,8 +51,7 @@
     "ember-cli-htmlbars": "^5.3.2",
     "ember-concurrency": "^2.0.0",
     "ember-in-element-polyfill": "^1.0.0",
-    "ember-modifier": "^2.1.2",
-    "tracked-toolbox": "^1.2.2"
+    "ember-modifier": "^2.1.2"
   },
   "devDependencies": {
     "@babel/plugin-proposal-logical-assignment-operators": "^7.13.8",
@@ -95,8 +95,7 @@
     "qunit": "^2.16.0",
     "qunit-dom": "^1.6.0",
     "release-it": "^14.6.1",
-    "release-it-lerna-changelog": "^3.1.0",
-    "tracked-maps-and-sets": "^2.2.1"
+    "release-it-lerna-changelog": "^3.1.0"
   },
   "resolutions": {
     "qunit": "~2.11.0"

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "broccoli-funnel": ">=2.0.0",
     "camelcase": "^6.0.0",
     "chalk": "^4.1.0",
+    "ember-cache-primitive-polyfill": "^1.0.1",
     "ember-cli-babel": "^7.23.1",
     "ember-cli-htmlbars": "^5.3.2",
     "ember-concurrency": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2237,6 +2237,15 @@
   dependencies:
     "@octokit/openapi-types" "^6.1.1"
 
+"@sandydoo/tracked-maps-and-sets@^2.2.2":
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/@sandydoo/tracked-maps-and-sets/-/tracked-maps-and-sets-2.2.2.tgz#6c2b365618142f696b1e3a024c29f9081025528a"
+  integrity sha512-lnuf9fGvShbBxaX/ATHYi8tdADRFanxIWZGoJFsPdJbEpkXMWeMezVrq0DHUjwNvPcxTKKN3yACxmVEz8HvZkA==
+  dependencies:
+    "@glimmer/tracking" "^1.0.0"
+    ember-cli-babel "^7.26.5"
+    ember-compatibility-helpers "^1.2.4"
+
 "@simple-dom/interface@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@simple-dom/interface/-/interface-1.4.0.tgz#e8feea579232017f89b0138e2726facda6fbb71f"
@@ -3181,13 +3190,6 @@ babel-plugin-ember-modules-api-polyfill@>=3.5.0, babel-plugin-ember-modules-api-
   integrity sha512-pJajN/DkQUnStw0Az8c6khVcMQHgzqWr61lLNtVeu0g61LRW0k9jyK7vaedrHDWGe/Qe8sxG5wpiyW9NsMqFzA==
   dependencies:
     ember-rfc176-data "^0.3.17"
-
-babel-plugin-ember-modules-api-polyfill@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-3.3.0.tgz#dc2599b0615ecb5d952aeadb5e309e5a5d970db6"
-  integrity sha512-ZHeadIPB6prIs6TzAItQl7VO0/Lcy74n47fl4oev4DOgB4iuRfL/CEpGZqm0B/9zODYn4GsE0taCC0HSDWqMYQ==
-  dependencies:
-    ember-rfc176-data "^0.3.16"
 
 babel-plugin-filter-imports@^4.0.0:
   version "4.0.0"
@@ -5464,16 +5466,6 @@ ember-auto-import@^1.10.1:
     walk-sync "^0.3.3"
     webpack "^4.43.0"
 
-ember-cache-primitive-polyfill@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/ember-cache-primitive-polyfill/-/ember-cache-primitive-polyfill-1.0.1.tgz#a27075443bd87e5af286c1cd8a7df24e3b9f6715"
-  integrity sha512-hSPcvIKarA8wad2/b6jDd/eU+OtKmi6uP+iYQbzi5TQpjsqV6b4QdRqrLk7ClSRRKBAtdTuutx+m+X+WlEd2lw==
-  dependencies:
-    ember-cli-babel "^7.22.1"
-    ember-cli-version-checker "^5.1.1"
-    ember-compatibility-helpers "^1.2.1"
-    silent-error "^1.1.1"
-
 ember-cli-addon-tests@^0.11.1:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/ember-cli-addon-tests/-/ember-cli-addon-tests-0.11.1.tgz#70c9164cb4126b2d17bbf9588ff34d97d4bfbad1"
@@ -5563,7 +5555,7 @@ ember-cli-babel@^7.1.2, ember-cli-babel@^7.22.1:
     rimraf "^3.0.1"
     semver "^5.5.0"
 
-ember-cli-babel@^7.10.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.26.4:
+ember-cli-babel@^7.10.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.26.4, ember-cli-babel@^7.26.5:
   version "7.26.6"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.26.6.tgz#322fbbd3baad9dd99e3276ff05bc6faef5e54b39"
   integrity sha512-040svtfj2RC35j/WMwdWJFusZaXmNoytLAMyBDGLMSlRvznudTxZjGlPV6UupmtTBApy58cEF8Fq4a+COWoEmQ==
@@ -5596,7 +5588,7 @@ ember-cli-babel@^7.10.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.26.4:
     rimraf "^3.0.1"
     semver "^5.5.0"
 
-ember-cli-babel@^7.13.0, ember-cli-babel@^7.21.0, ember-cli-babel@^7.23.1, ember-cli-babel@^7.26.2:
+ember-cli-babel@^7.13.0, ember-cli-babel@^7.23.1, ember-cli-babel@^7.26.2:
   version "7.26.3"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.26.3.tgz#e93ce7ec458208894d10844cf76e41cc06fdbeb6"
   integrity sha512-ZCs0g99d3kYaHs1+HT33oMY7/K+nLCAAv7dCLxsMzg7cQf55O6Pq4ZKnWEr3IHVs33xbJFnEb9prt1up36QVnw==
@@ -5615,39 +5607,6 @@ ember-cli-babel@^7.13.0, ember-cli-babel@^7.21.0, ember-cli-babel@^7.23.1, ember
     babel-plugin-debug-macros "^0.3.4"
     babel-plugin-ember-data-packages-polyfill "^0.1.2"
     babel-plugin-ember-modules-api-polyfill "^3.5.0"
-    babel-plugin-module-resolver "^3.2.0"
-    broccoli-babel-transpiler "^7.8.0"
-    broccoli-debug "^0.6.4"
-    broccoli-funnel "^2.0.2"
-    broccoli-source "^2.1.2"
-    clone "^2.1.2"
-    ember-cli-babel-plugin-helpers "^1.1.1"
-    ember-cli-version-checker "^4.1.0"
-    ensure-posix-path "^1.0.2"
-    fixturify-project "^1.10.0"
-    resolve-package-path "^3.1.0"
-    rimraf "^3.0.1"
-    semver "^5.5.0"
-
-ember-cli-babel@^7.17.2:
-  version "7.24.0"
-  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.24.0.tgz#d58670d0f214c63a46f44f86e7c407799d77fc45"
-  integrity sha512-IpqMqOS1VI2wVLIREdEXG9WG05YBulg20t0K27yl2aBjmShvLMRIodcNiKataTgf/dDiU0EWQBGl7VLBLBkFgQ==
-  dependencies:
-    "@babel/core" "^7.12.0"
-    "@babel/helper-compilation-targets" "^7.12.0"
-    "@babel/plugin-proposal-class-properties" "^7.10.4"
-    "@babel/plugin-proposal-decorators" "^7.10.5"
-    "@babel/plugin-transform-modules-amd" "^7.10.5"
-    "@babel/plugin-transform-runtime" "^7.12.0"
-    "@babel/plugin-transform-typescript" "^7.12.0"
-    "@babel/polyfill" "^7.11.5"
-    "@babel/preset-env" "^7.12.0"
-    "@babel/runtime" "^7.12.0"
-    amd-name-resolver "^1.3.1"
-    babel-plugin-debug-macros "^0.3.4"
-    babel-plugin-ember-data-packages-polyfill "^0.1.2"
-    babel-plugin-ember-modules-api-polyfill "^3.3.0"
     babel-plugin-module-resolver "^3.2.0"
     broccoli-babel-transpiler "^7.8.0"
     broccoli-debug "^0.6.4"
@@ -6138,7 +6097,7 @@ ember-rfc176-data@^0.3.15:
   resolved "https://registry.yarnpkg.com/ember-rfc176-data/-/ember-rfc176-data-0.3.16.tgz#2ace0ac9cf9016d493a74a1d931643a308679803"
   integrity sha512-IYAzffS90r2ybAcx8c2qprYfkxa70G+/UPkxMN1hw55DU5S2aLOX6v3umKDZItoRhrvZMCnzwsdfKSrKdC9Wbg==
 
-ember-rfc176-data@^0.3.16, ember-rfc176-data@^0.3.17:
+ember-rfc176-data@^0.3.17:
   version "0.3.17"
   resolved "https://registry.yarnpkg.com/ember-rfc176-data/-/ember-rfc176-data-0.3.17.tgz#d4fc6c33abd6ef7b3440c107a28e04417b49860a"
   integrity sha512-EVzTTKqxv9FZbEh6Ktw56YyWRAA0MijKvl7H8C06wVF+8f/cRRz3dXxa4nkwjzyVwx4rzKGuIGq77hxJAQhWWw==
@@ -12885,24 +12844,6 @@ tr46@^2.0.2:
   integrity sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==
   dependencies:
     punycode "^2.1.1"
-
-tracked-maps-and-sets@^2.0.0, tracked-maps-and-sets@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/tracked-maps-and-sets/-/tracked-maps-and-sets-2.2.1.tgz#323dd40540c561e8b0ffdec8bf129c68ec5025f9"
-  integrity sha512-XYrXh6L/GpGmVmG3KcN/qoDyi4FxHh8eZY/BA/RuoxynskV+GZSfwrX3R+5DR2CIkzkCx4zi4kkDRg1AMDfDhg==
-  dependencies:
-    "@glimmer/tracking" "^1.0.0"
-    ember-cli-babel "^7.17.2"
-
-tracked-toolbox@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/tracked-toolbox/-/tracked-toolbox-1.2.2.tgz#1669225a13371b66da8e98521258b51ce0c18909"
-  integrity sha512-lI7O4nyISRAznMloK/MalPXCANIGabfqFcnUxNuRctPfRT/G//RPQcjoSKQMkbiBjdrStfIssik23hyd/EtAWQ==
-  dependencies:
-    ember-cache-primitive-polyfill "^1.0.0"
-    ember-cli-babel "^7.21.0"
-    ember-cli-htmlbars "^5.3.1"
-    tracked-maps-and-sets "^2.0.0"
 
 tree-sync@^1.2.2:
   version "1.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5466,6 +5466,16 @@ ember-auto-import@^1.10.1:
     walk-sync "^0.3.3"
     webpack "^4.43.0"
 
+ember-cache-primitive-polyfill@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/ember-cache-primitive-polyfill/-/ember-cache-primitive-polyfill-1.0.1.tgz#a27075443bd87e5af286c1cd8a7df24e3b9f6715"
+  integrity sha512-hSPcvIKarA8wad2/b6jDd/eU+OtKmi6uP+iYQbzi5TQpjsqV6b4QdRqrLk7ClSRRKBAtdTuutx+m+X+WlEd2lw==
+  dependencies:
+    ember-cli-babel "^7.22.1"
+    ember-cli-version-checker "^5.1.1"
+    ember-compatibility-helpers "^1.2.1"
+    silent-error "^1.1.1"
+
 ember-cli-addon-tests@^0.11.1:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/ember-cli-addon-tests/-/ember-cli-addon-tests-0.11.1.tgz#70c9164cb4126b2d17bbf9588ff34d97d4bfbad1"


### PR DESCRIPTION
This fork fixes the Ember global deprecation in newer Ember versions.
The maintainers don't want to patch this and are preparing to drop
support for anything older than `3.24`. What are you gonna do.

Also, drop `tracked-toolbox` becasue we weren't using it.