### PR TITLE
Don't error out when setting an undefined option

### DIFF
--- a/addon/utils/options-and-events.js
+++ b/addon/utils/options-and-events.js
@@ -142,15 +142,15 @@ class ArgsProxyHandler {
     return this.setCache.get(prop) ?? this.getFromArgs(prop);
   }
 
-  // TODO: Google Maps like to set default stuff. Check how this is going to
-  // work.
   set(_target, prop, value) {
     if (value !== undefined) {
       this.setCache.set(prop, value);
-      return value;
     } else {
       this.setCache.delete(prop);
     }
+
+    // Never fail to set a value
+    return true;
   }
 
   has(_target, prop) {

--- a/tests/integration/components/g-map-test.js
+++ b/tests/integration/components/g-map-test.js
@@ -10,6 +10,18 @@ module('Integration | Component | g map', function (hooks) {
   setupMapTest(hooks);
   setupLocations(hooks);
 
+  test('it renders without any coordinates or options', async function (assert) {
+    // Google Maps considers all options optional, so this should just render a
+    // gray square and not throw any errors.
+    await render(hbs`
+      <GMap />
+    `);
+
+    let api = await this.waitForMap();
+
+    assert.ok(api.map);
+  });
+
   test('it renders a map', async function (assert) {
     await render(hbs`
       <GMap @lat={{this.lat}} @lng={{this.lng}} @zoom={{12}} />


### PR DESCRIPTION
We were setting `center` to `undefined` when drawing a map without
coordinates. That actually produced a reasonable error message because
the setter returned `false` when trying to delete the non-existent
`center` key from the set cache.

We now return `true` from the setter so that it doesn't error out.
This also means that `center` is now an optional argument.

Fixes #120.