### PR TITLE
Unregister components on teardown

### DIFF
--- a/addon/components/g-map/map-component.js
+++ b/addon/components/g-map/map-component.js
@@ -60,10 +60,17 @@ export default class MapComponent {
     if (mapComponent) {
       mapComponent.setMap?.(null);
     }
+
+    // Unregister from the parent component
+    this.onTeardown?.();
   }
 
   register() {
-    this.context = this.args.getContext?.(this.publicAPI, this.name);
+    if (typeof this.args.getContext === 'function') {
+      let { context, remove } = this.args.getContext(this.publicAPI, this.name);
+      this.context = context;
+      this.onTeardown = remove;
+    }
   }
 
   /* Events */

--- a/tests/integration/components/g-map/marker-test.js
+++ b/tests/integration/components/g-map/marker-test.js
@@ -63,4 +63,30 @@ module('Integration | Component | g map/marker', function (hooks) {
 
     assert.equal(marker.draggable, true);
   });
+
+  test('it unregisters a marker on teardown', async function (assert) {
+    assert.expect(2);
+
+    this.set('showMarker', true);
+
+    await render(hbs`
+      <GMap @lat={{this.lat}} @lng={{this.lng}} as |g|>
+        {{#if this.showMarker}}
+          <g.marker @lat={{this.lat}} @lng={{this.lng}} @draggable={{true}} />
+        {{/if}}
+      </GMap>
+    `);
+
+    let {
+      components: { markers },
+    } = await this.waitForMap();
+
+    assert.equal(markers.length, 1, 'marker registered');
+
+    this.set('showMarker', false);
+    await this.waitForMap();
+
+    // This tests makes sure that the markers array is updated.
+    assert.equal(markers.length, 0, 'marker unregistered');
+  });
 });


### PR DESCRIPTION
I forgot to reimplement this before releasing the Octane rewrite 🤦 Since we weren't unregistering components, if you drew a marker and then removed it, the map would still say you had one marker on the map.