### PR TITLE
Fix redirect on 404 in docs

### DIFF
--- a/docs/app/router.js
+++ b/docs/app/router.js
@@ -15,7 +15,7 @@ export default class Router extends EmberRouter {
 }
 
 Router.map(function () {
-  this.route('docs', { path: '/*path' });
+  this.route('not-found', { path: '/*path' });
 
   this.route('index', { path: '/' });
 

--- a/docs/app/routes/docs.js
+++ b/docs/app/routes/docs.js
@@ -1,7 +1,0 @@
-import Route from '@ember/routing/route';
-
-export default class DocsRoute extends Route {
-  beforeModel() {
-    this.replaceWith('docs.getting-started');
-  }
-}

--- a/docs/app/routes/not-found.js
+++ b/docs/app/routes/not-found.js
@@ -1,0 +1,7 @@
+import Route from '@ember/routing/route';
+
+export default class NotFoundRoute extends Route {
+  beforeModel() {
+    this.transitionTo('docs.getting-started');
+  }
+}

--- a/docs/app/templates/not-found.hbs
+++ b/docs/app/templates/not-found.hbs
@@ -1,0 +1,2 @@
+{{page-title "NotFound"}}
+{{outlet}}


### PR DESCRIPTION
This was accidentally sending everyone to `getting-started` when
reloading or navigating to a docs subroute directly.

[skip ci]