### PR TITLE
Tear down components that don't have an update method

### DIFF
--- a/addon/component-managers/map-component-manager.js
+++ b/addon/component-managers/map-component-manager.js
@@ -98,6 +98,11 @@ export class MapComponentManager {
       });
     } else {
       effect = setupEffect(() => {
+        // Teardown the previous map component if it exists
+        if (mapComponent) {
+          component.teardown(mapComponent);
+        }
+
         mapComponent = component.setup(component.options, component.events);
 
         component.mapComponent = mapComponent;


### PR DESCRIPTION
Sometimes it doesn't make sense for a map component to have a dedicated
update method. But that doesn't mean that there's nothing to clean up
before running the setup method again.