### PR TITLE
Fix issue where directions were re-fetched when resolved

### DIFF
--- a/addon/effects/tracking.js
+++ b/addon/effects/tracking.js
@@ -2,6 +2,10 @@ import { createCache, getValue } from '@glimmer/tracking/primitives/cache';
 import { _backburner } from '@ember/runloop';
 import { registerDestructor } from '@ember/destroyable';
 
+// TODO Revisit when Glimmer gets effects
+import Ember from 'ember';
+const { untrack } = Ember.__loader.require('@glimmer/validator');
+
 /**
  * It’s been clear since launch that Octane’s design doesn’t account for a few
  * important use-cases:
@@ -65,15 +69,10 @@ function teardownEffect(effect) {
 export function setupEffect(fn) {
   let effect = createCache(fn);
 
-  // Force the computation immediately, because there seems to be a timing issue
-  // with backburner and promises. The effects just aren’t run if they’re added
-  // when a promise resolves. Perhaps it’s a matter of making sure we’re in a
-  // runloop when we resolve, but I’m not yet sure where that needs to happen.
-  getValue(effect);
-
   EFFECTS_TO_RUN.add(effect);
-
   registerDestructor(effect, teardownEffect);
 
   return effect;
 }
+
+export { untrack };

--- a/addon/effects/tracking.js
+++ b/addon/effects/tracking.js
@@ -3,8 +3,12 @@ import { _backburner } from '@ember/runloop';
 import { registerDestructor } from '@ember/destroyable';
 
 // TODO Revisit when Glimmer gets effects
+let untrack = (fn) => fn();
+
 import Ember from 'ember';
-const { untrack } = Ember.__loader.require('@glimmer/validator');
+if (Object.keys(Ember.__loader.registry).includes('@glimmer/validator')) {
+  ({ untrack } = Ember.__loader.require('@glimmer/validator'));
+}
 
 /**
  * It’s been clear since launch that Octane’s design doesn’t account for a few

--- a/tests/integration/components/g-map/directions-test.js
+++ b/tests/integration/components/g-map/directions-test.js
@@ -20,8 +20,8 @@ module('Integration | Component | g-map/directions', function (hooks) {
   });
 
   test('it fetches directions', async function (assert) {
-    this.origin = 'Covent Garden';
-    this.destination = 'Clerkenwell';
+    this.set('origin', 'Covent Garden');
+    this.set('destination', 'Clerkenwell');
 
     await render(hbs`
       <GMap @lat={{this.lat}} @lng={{this.lng}} as |g|>


### PR DESCRIPTION
`ember-concurrency` tracks its internal properties, so it ends up
triggering the effect a second time once it resolves. I guess we
could "changeset" the options to avoid this, but there's more. Because
it runs in the same computation as this effect, you can't even
check`isRunning` without triggering an error from Glimmer. That's not
particularly great, and I guess the solution might have to happen
upstream (scheduling or track/untrack frames). Let's see what comes out
of Glimmer's effect system and revisit.