### PR TITLE
Fix errors trying to find a `template` component

### DIFF
--- a/lib/ast-transforms/addon-factory.js
+++ b/lib/ast-transforms/addon-factory.js
@@ -18,10 +18,6 @@ function makeAddonFactory(addons = {}) {
     }
 
     transform(ast) {
-      if (Object.keys(addons).length === 0) {
-        return ast;
-      }
-
       if (this.moduleName !== 'ember-google-maps/components/g-map.hbs') {
         return ast;
       }
@@ -34,6 +30,12 @@ function makeAddonFactory(addons = {}) {
             let pairs = node.params[0].hash.pairs;
             let templatePair = extractCustomComponentTemplate(pairs);
             let template = templatePair.value;
+
+            // Skip if there are no addons, but only after removing the template
+            // component
+            if (Object.keys(addons).length === 0) {
+              return;
+            }
 
             let addonComponents = [];
 


### PR DESCRIPTION
The `template` component isn't a valid component, so it should always be removed,
even when there aren't any addons to add to the template.