### PR TITLE
Fix teardown errors in FastBoot

### DIFF
--- a/addon/component-managers/map-component-manager.js
+++ b/addon/component-managers/map-component-manager.js
@@ -57,9 +57,11 @@ export class MapComponentManager {
   }
 
   destroyComponent(component) {
-    destroy(component);
+    if (component.mapComponent) {
+      component?.teardown(component.mapComponent);
+    }
 
-    component.teardown(component.mapComponent);
+    destroy(component);
   }
 
   getContext(component) {


### PR DESCRIPTION
Don't tear down if there is no map component. That way it also
shouldn't run in FastBoot, since the setup method is never run
in FastBoot.