### PR TITLE
Return the `google` global from the API service if Google Maps has already been loaded

### DIFF
--- a/addon/services/google-maps-api.js
+++ b/addon/services/google-maps-api.js
@@ -51,7 +51,7 @@ export default class GoogleMapsApiService extends Service {
     }
 
     if (window?.google?.maps) {
-      return resolve(window.google.maps);
+      return resolve(window.google);
     }
 
     let config = this._getConfig();


### PR DESCRIPTION
On the GoogleMapsApiService, the _getApi() should return window.google, not window.google.maps right?

After I install the ember-place-autocomplete addon this one is failing to load the Google Maps API. The _loadAndInitApi() function resolves window.google after it loads, and the getter directionsService() tries to access the .maps property. So returning window.google.maps on _getAPI() fails on the getter as it tries to access the maps property by a second time. I think this is a bug added like 4 months ago.

I don't know why the tests are failing, looks like the tests don't have an API Key set.