### PR TITLE
Refactor AST plugins to match new plugin format

### DIFF
--- a/lib/ast-transforms/addon-factory.js
+++ b/lib/ast-transforms/addon-factory.js
@@ -11,56 +11,50 @@ function extractCustomComponentTemplate(pairs) {
 }
 
 function makeAddonFactory(addons = {}) {
-  return class AddonFactory {
-    constructor(env) {
-      this.moduleName = env.moduleName;
-      this.syntax = env.syntax;
+  let name = 'addon-factory';
+  let doNothing = { name, visitor: {} };
+
+  return (env) => {
+    if (env.moduleName !== 'ember-google-maps/components/g-map.hbs') {
+      return doNothing;
     }
 
-    transform(ast) {
-      if (this.moduleName !== 'ember-google-maps/components/g-map.hbs') {
-        return ast;
-      }
+    let b = env.syntax.builders;
 
-      let b = this.syntax.builders;
+    let visitor = {
+      MustacheStatement(node) {
+        if (node.path.original === 'yield') {
+          let pairs = node.params[0].hash.pairs;
+          let templatePair = extractCustomComponentTemplate(pairs);
+          let template = templatePair.value;
 
-      let visitor = {
-        MustacheStatement(node) {
-          if (node.path.original === 'yield') {
-            let pairs = node.params[0].hash.pairs;
-            let templatePair = extractCustomComponentTemplate(pairs);
-            let template = templatePair.value;
-
-            // Skip if there are no addons, but only after removing the template
-            // component
-            if (Object.keys(addons).length === 0) {
-              return;
-            }
-
-            let addonComponents = [];
-
-            for (let [name, componentPath] of Object.entries(addons)) {
-              let addon = b.sexpr(
-                template.path,
-                [b.string(componentPath)],
-                template.hash,
-                template.loc
-              );
-
-              addonComponents.push(b.pair(name, addon, templatePair.loc));
-            }
-
-            for (let addon of addonComponents) {
-              pairs.push(addon);
-            }
+          // Skip if there are no addons, but only after removing the template
+          // component
+          if (Object.keys(addons).length === 0) {
+            return;
           }
-        },
-      };
 
-      this.syntax.traverse(ast, visitor);
+          let addonComponents = [];
 
-      return ast;
-    }
+          for (let [name, componentPath] of Object.entries(addons)) {
+            let addon = b.sexpr(
+              template.path,
+              [b.string(componentPath)],
+              template.hash,
+              template.loc
+            );
+
+            addonComponents.push(b.pair(name, addon, templatePair.loc));
+          }
+
+          for (let addon of addonComponents) {
+            pairs.push(addon);
+          }
+        }
+      },
+    };
+
+    return { name, visitor };
   };
 }
 

--- a/lib/ast-transforms/canvas-enforcer.js
+++ b/lib/ast-transforms/canvas-enforcer.js
@@ -2,86 +2,81 @@
 
 const getBuilders = require('./builders');
 
-class CanvasEnforcer {
-  constructor(env) {
-    this.syntax = env.syntax;
-  }
+function enforceCanvas(env) {
+  let b = getBuilders(env.syntax);
 
-  transform(ast) {
-    let b = getBuilders(this.syntax);
+  let visitor = {
+    BlockStatement(node) {
+      if (node.path.original === 'g-map') {
+        let program = node.program;
 
-    let visitor = {
-      BlockStatement(node) {
-        if (node.path.original === 'g-map') {
-          let program = node.program;
+        let children = program.body,
+          blockParam = program.blockParams;
 
-          let children = program.body,
-            blockParam = program.blockParams;
-
-          if (hasCanvas(children, blockParam)) {
-            return;
-          }
-
-          // No need to parse classNames; we pass them via the component.
-
-          let canvas = b.mustache(b.path(`${blockParam}.canvas`));
-
-          children.unshift(canvas);
+        if (hasCanvas(children, blockParam)) {
+          return;
         }
-      },
 
-      ElementNode(node) {
-        if (node.tag === 'GMap' || node.tag === 'g-map') {
-          // Self-closing tag
-          if (node.selfClosing) {
-            return;
-          }
+        // No need to parse classNames; we pass them via the component.
 
-          let children = node.children,
-            blockParam = node.blockParams[0];
+        let canvas = b.mustache(b.path(`${blockParam}.canvas`));
 
-          if (hasCanvas(children, blockParam)) {
-            return;
-          }
+        children.unshift(canvas);
+      }
+    },
 
-          let attributes = new Map(
-            node.attributes
-              .filter(({ name }) => name.charAt(0) !== '@')
-              .map((a) => [a.name, a])
-          );
-
-          let classAttr = attributes.get('class');
-
-          if (classAttr) {
-            classAttr.value.chars += ' ember-google-map';
-            attributes.set('class', classAttr);
-          } else {
-            let defaultClass = b.attr('class', b.text('ember-google-map'));
-            attributes.set('class', defaultClass);
-          }
-
-          let canvas = b.element(
-            {
-              name: `${blockParam}.canvas`,
-              selfClosing: true,
-            },
-            Array.from(attributes.values()),
-            [],
-            [],
-            undefined,
-            [],
-            node.loc
-          );
-
-          children.unshift(canvas);
+    ElementNode(node) {
+      if (node.tag === 'GMap' || node.tag === 'g-map') {
+        // Self-closing tag
+        if (node.selfClosing) {
+          return;
         }
-      },
-    };
 
-    this.syntax.traverse(ast, visitor);
+        let children = node.children,
+          blockParam = node.blockParams[0];
 
-    return ast;
-  }
+        if (hasCanvas(children, blockParam)) {
+          return;
+        }
+
+        let attributes = new Map(
+          node.attributes
+            .filter(({ name }) => name.charAt(0) !== '@')
+            .map((a) => [a.name, a])
+        );
+
+        let classAttr = attributes.get('class');
+
+        if (classAttr) {
+          classAttr.value.chars += ' ember-google-map';
+          attributes.set('class', classAttr);
+        } else {
+          let defaultClass = b.attr('class', b.text('ember-google-map'));
+          attributes.set('class', defaultClass);
+        }
+
+        let canvas = b.element(
+          {
+            name: `${blockParam}.canvas`,
+            selfClosing: true,
+          },
+          Array.from(attributes.values()),
+          [],
+          [],
+          undefined,
+          [],
+          node.loc
+        );
+
+        children.unshift(canvas);
+      }
+    },
+  };
+
+  return {
+    name: 'canvas-enforcer',
+    visitor,
+  };
 }
 
 function hasCanvas(nodes, blockParam) {
@@ -100,4 +95,4 @@ function hasCanvas(nodes, blockParam) {
   return false;
 }
 
-module.exports = CanvasEnforcer;
+module.exports = enforceCanvas;

--- a/lib/ast-transforms/treeshaker.js
+++ b/lib/ast-transforms/treeshaker.js
@@ -3,85 +3,79 @@
 const { newExcludeName, skipTreeshaking } = require('../treeshaking');
 
 function makeTreeshaker(params) {
-  return class Treeshaker {
-    constructor(env) {
-      this.moduleName = env.moduleName;
-      this.syntax = env.syntax;
+  let name = 'treeshaker';
+  let doNothing = { name, visitor: {} };
+
+  return (env) => {
+    if (env.moduleName !== 'ember-google-maps/components/g-map.hbs') {
+      return doNothing;
     }
 
-    transform(ast) {
-      if (this.moduleName !== 'ember-google-maps/components/g-map.hbs') {
-        return ast;
-      }
+    let { included, excluded, isProduction } = params;
 
-      let { included, excluded, isProduction } = params;
+    let shouldExcludeName = newExcludeName(included, excluded);
+    let shouldSkipTreeshaking = skipTreeshaking(included, excluded);
 
-      let shouldExcludeName = newExcludeName(included, excluded);
-      let shouldSkipTreeshaking = skipTreeshaking(included, excluded);
+    if (shouldSkipTreeshaking) {
+      return doNothing;
+    }
 
-      if (shouldSkipTreeshaking) {
-        return ast;
-      }
+    let b = env.syntax.builders;
 
-      let b = this.syntax.builders;
+    let visitor = {
+      MustacheStatement(node) {
+        if (node.path.original === 'yield') {
+          let hash = node.params[0].hash;
+          let pairs = hash.pairs;
 
-      let visitor = {
-        MustacheStatement(node) {
-          if (node.path.original === 'yield') {
-            let hash = node.params[0].hash;
-            let pairs = hash.pairs;
+          let newPairs = [];
 
-            let newPairs = [];
-
-            for (let pair of pairs) {
-              // Include non-component data
-              if (['map', 'canvas'].includes(pair.key)) {
-                newPairs.push(pair);
-                continue;
-              }
-
-              // Check if this is a component
-              let compExpr = pair.value;
-              if (!compExpr) {
-                newPairs.push(pair);
-                continue;
-              }
-
-              if (shouldExcludeName(pair.key)) {
-                // Exclude components that we don't want in the production build.
-                if (isProduction) {
-                  continue;
-                }
-
-                // Replace an excluded component with a debug component in
-                // development and testing. This component should warn the user
-                // of misconfigured treeshaking.
-                let warnMissing = b.pair(
-                  pair.key,
-                  b.sexpr(
-                    compExpr.path,
-                    [b.string('-private-api/warn-missing-component')],
-                    b.hash([b.pair('name', b.string(pair.key))])
-                  )
-                );
-
-                newPairs.push(warnMissing);
-                continue;
-              }
-
-              // Add components that aren’t excluded
+          for (let pair of pairs) {
+            // Include non-component data
+            if (['map', 'canvas'].includes(pair.key)) {
               newPairs.push(pair);
+              continue;
             }
 
-            hash.pairs = newPairs;
+            // Check if this is a component
+            let compExpr = pair.value;
+            if (!compExpr) {
+              newPairs.push(pair);
+              continue;
+            }
+
+            if (shouldExcludeName(pair.key)) {
+              // Exclude components that we don't want in the production build.
+              if (isProduction) {
+                continue;
+              }
+
+              // Replace an excluded component with a debug component in
+              // development and testing. This component should warn the user
+              // of misconfigured treeshaking.
+              let warnMissing = b.pair(
+                pair.key,
+                b.sexpr(
+                  compExpr.path,
+                  [b.string('-private-api/warn-missing-component')],
+                  b.hash([b.pair('name', b.string(pair.key))])
+                )
+              );
+
+              newPairs.push(warnMissing);
+              continue;
+            }
+
+            // Add components that aren’t excluded
+            newPairs.push(pair);
           }
-        },
-      };
 
-      this.syntax.traverse(ast, visitor);
+          hash.pairs = newPairs;
+        }
+      },
+    };
 
-      return ast;
-    }
+    return { name, visitor };
   };
 }
 


### PR DESCRIPTION
There isn't any documentation on how to write these AST plugins. Until
now, I would base the design on whatever rjwblue was doing, because,
you know, core-team and everything. With Ember@4.0 the class-based
design he uses doesn't work. The plugin now HAS to be a function that
returns an object with the visitor (see here: https://github.com/glimmerjs/glimmer-vm/blob/ef92c497c3d921af22b38a54eac1445c204c3370/packages/%40glimmer/syntax/lib/parser/tokenizer-event-handlers.ts#L318-L325)