### PR TITLE
Add an acceptance test to the test suite

### DIFF
--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -1,4 +1,4 @@
-import setupMapTest from './setup-map';
+import { setupMapTest, waitForMap } from './setup-map';
 import { getDirectionsQuery, trigger } from './helpers';
 
-export { getDirectionsQuery, setupMapTest, trigger };
+export { getDirectionsQuery, setupMapTest, trigger, waitForMap };

--- a/addon-test-support/setup-map.js
+++ b/addon-test-support/setup-map.js
@@ -1,5 +1,6 @@
 import GMap from 'ember-google-maps/components/g-map';
 import { settled } from '@ember/test-helpers';
+import { action } from '@ember/object';
 
 let lastKey;
 const MAP_STORE = new Map();
@@ -23,21 +24,22 @@ function resetStore() {
 
 export async function waitForMap(id) {
   await settled();
-
   return getFromStore(id);
 }
 
-export default function setupMapTest(hooks) {
+export function setupMapTest(hooks) {
   hooks.beforeEach(function () {
     this.waitForMap = waitForMap.bind(this);
 
+    // TODO can we do this from within g-map? I guess the main issue with that
+    // is figuring out how to remove all this code from the production build.
     this.owner.register(
       'component:g-map',
       class InstrumentedGMap extends GMap {
-        constructor() {
-          super(...arguments);
-
-          addToStore(this.id, this.publicAPI);
+        @action
+        getCanvas(canvas) {
+          super.getCanvas(canvas);
+          addToStore(canvas.id, this.publicAPI);
         }
       }
     );

--- a/tests/acceptance/app-test.js
+++ b/tests/acceptance/app-test.js
@@ -1,0 +1,27 @@
+import { module, test } from 'qunit';
+import { visit, waitFor } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import {
+  setupMapTest,
+  trigger,
+  waitForMap,
+} from 'ember-google-maps/test-support';
+
+module('Acceptance | app', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMapTest(hooks);
+
+  test('visiting /', async function (assert) {
+    await visit('/');
+    let { components } = await waitForMap('main-map');
+
+    let marker = components.markers
+      .map((marker) => marker.mapComponent)
+      .find((marker) => marker.id === 'main-marker');
+
+    trigger(marker, 'click');
+
+    let infoWindow = await waitFor('[data-test-info-window]');
+    assert.dom(infoWindow).hasText('You clicked me!');
+  });
+});

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -1,0 +1,18 @@
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+export default class ApplicationController extends Controller {
+  london = {
+    lat: '51.507568',
+    lng: '-0.127762',
+  };
+
+  @tracked
+  markerTooltipOpen = false;
+
+  @action
+  toggle(key, obj) {
+    obj[key] = !obj[key];
+  }
+}

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,1 +1,15 @@
-{{outlet}}
+<GMap id="main-map" @lat={{this.london.lat}} @lng={{this.london.lng}} as |map|>
+  <map.marker
+    @id="main-marker"
+    @lat={{this.london.lat}}
+    @lng={{this.london.lng}}
+    @onClick={{fn this.toggle "markerTooltipOpen" this}} as |marker|>
+
+    <marker.infoWindow
+      @isOpen={{this.markerTooltipOpen}}
+      @onCloseclick={{fn (mut this.markerTooltipOpen) false}}>
+      <span data-test-info-window>You clicked me!</span>
+    </marker.infoWindow>
+
+  </map.marker>
+</GMap>


### PR DESCRIPTION
We’re not really testing anything useful here — our usual integration
tests cover this. But it’s nice to actually run an acceptance test in
case something breaks within that context.