### PR TITLE
Drop support for the `onLoad` event

### DIFF
--- a/addon/components/g-map.js
+++ b/addon/components/g-map.js
@@ -6,7 +6,6 @@ import { toLatLng } from '../utils/helpers';
 
 import { waitFor } from '@ember/test-waiters';
 import { DEBUG } from '@glimmer/env';
-import { deprecate } from '@ember/debug';
 
 function GMapPublicAPI(source) {
   return {
@@ -49,35 +48,6 @@ export default class GMap extends MapComponent {
     let map = new google.maps.Map(this.canvas, this.newOptions);
 
     this.addEventsToMapComponent(map, events, this.publicAPI);
-
-    if (typeof this.args.onLoad === 'function') {
-      deprecate(
-        `The \`onLoad\` event has been deprecated. You should replace it with \`onceOnIdle\`.
-
-        If you had the following:
-
-        <GMap @lat={{this.lat}} @lng={{this.lng}} @onLoad={{this.didLoadMap}} />
-
-        Replace it with:
-
-        <GMap @lat={{this.lat}} @lng={{this.lng}} @onceOnIdle={{this.didLoadMap}} />
-
-        `.replace(/^[\s]+/gm, '\n'),
-        false,
-        {
-          id: 'events.onLoad',
-          until: '5.0.0',
-          for: 'ember-google-maps',
-          since: {
-            enabled: '4.0.0-beta.8',
-          },
-        }
-      );
-
-      google.maps.event.addListenerOnce(map, 'idle', () => {
-        this.args.onLoad(this.publicAPI);
-      });
-    }
 
     if (DEBUG) {
       this.pauseTestForIdle(map);

--- a/addon/utils/options-and-events.js
+++ b/addon/utils/options-and-events.js
@@ -3,13 +3,7 @@ import { next } from '@ember/runloop';
 
 import { HAS_NATIVE_PROXY } from './platform';
 
-export const ignoredOptions = [
-  'lat',
-  'lng',
-  'getContext',
-  'classNames',
-  'onLoad',
-];
+export const ignoredOptions = ['lat', 'lng', 'getContext', 'classNames'];
 
 const IGNORED = Symbol('Ignored'),
   EVENT = Symbol('Event'),

--- a/tests/integration/components/g-map-test.js
+++ b/tests/integration/components/g-map-test.js
@@ -137,39 +137,6 @@ module('Integration | Component | g map', function (hooks) {
     await this.waitForMap();
   });
 
-  test('it deprecates the custom onLoad event', async function (assert) {
-    assert.expect(2);
-
-    let originalConsoleWarn = console.warn;
-
-    console.warn = (msg) => {
-      let msgText = msg.text ?? msg;
-
-      let test = /The `onLoad` event has been deprecated/.test(msgText);
-      assert.ok(test, 'Using the onLoad event displays a deprecation notice');
-
-      if (!test) {
-        originalConsoleWarn(msg);
-      }
-    };
-
-    this.onLoad = () => {
-      assert.ok(true, 'onLoad is still called');
-    };
-
-    await render(hbs`
-      <GMap
-        @lat={{this.lat}}
-        @lng={{this.lng}}
-        @zoom={{12}}
-        @onLoad={{this.onLoad}} />
-    `);
-
-    await this.waitForMap();
-
-    console.warn = originalConsoleWarn;
-  });
-
   test('it accepts both an events hash and individual attribute events', async function (assert) {
     assert.expect(2);
 


### PR DESCRIPTION
The `onLoad` event has been deprecated. You should replace it with `onceOnIdle`.

If you had the following:

```hbs
<GMap @lat={{this.lat}} @lng={{this.lng}} @onLoad={{this.didLoadMap}} />
```

Replace it with:

```hbs
<GMap @lat={{this.lat}} @lng={{this.lng}} @onceOnIdle={{this.didLoadMap}} />
```