### PR TITLE
Drop support for `@classNames`. Use `class` instead.

### DIFF
--- a/addon/components/g-map.hbs
+++ b/addon/components/g-map.hbs
@@ -1,7 +1,6 @@
 {{#let (component 'g-map/canvas' onCanvasReady=this.getCanvas) as |Canvas|}}
   {{#unless (has-block-params)}}
-    {{!-- Compatibility: @classNames should be deprecated --}}
-    <Canvas class={{@classNames}} ...attributes />
+    <Canvas ...attributes />
   {{/unless}}
 
   {{yield (hash

--- a/addon/components/g-map/control.hbs
+++ b/addon/components/g-map/control.hbs
@@ -1,6 +1,5 @@
 {{#if this.container}}
   {{#in-element this.container}}
-    {{!-- Compatibility: @classNames should be deprecated --}}
-    <div id={{this.id}} class={{@classNames}} ...attributes {{g-map/did-insert this.getControl}}>{{yield}}</div>
+    <div id={{this.id}} ...attributes {{g-map/did-insert this.getControl}}>{{yield}}</div>
   {{/in-element}}
 {{/if}}

--- a/addon/utils/options-and-events.js
+++ b/addon/utils/options-and-events.js
@@ -3,7 +3,7 @@ import { next } from '@ember/runloop';
 
 import { HAS_NATIVE_PROXY } from './platform';
 
-export const ignoredOptions = ['lat', 'lng', 'getContext', 'classNames'];
+export const ignoredOptions = ['lat', 'lng', 'getContext'];
 
 const IGNORED = Symbol('Ignored'),
   EVENT = Symbol('Event'),

--- a/lib/ast-transforms/canvas-enforcer.js
+++ b/lib/ast-transforms/canvas-enforcer.js
@@ -17,8 +17,6 @@ function enforceCanvas(env) {
           return;
         }
 
-        // No need to parse classNames; we pass them via the component.
-
         let canvas = b.mustache(b.path(`${blockParam}.canvas`));
 
         children.unshift(canvas);

--- a/tests/integration/components/g-map/canvas-test.js
+++ b/tests/integration/components/g-map/canvas-test.js
@@ -40,17 +40,6 @@ module('Integration | Component | g map/canvas', function (hooks) {
     );
   });
 
-  test('compatibility: it passes class names via `@classNames` to the default canvas', async function (assert) {
-    await render(hbs`
-      <GMap @lat={{this.lat}} @lng={{this.lng}} @classNames="extra-class-names" />
-    `);
-
-    assert.ok(
-      find('.extra-class-names'),
-      'canvas rendered with extra class names'
-    );
-  });
-
   test('it renders a custom canvas div', async function (assert) {
     await render(hbs`
       <GMap @lat={{this.lat}} @lng={{this.lng}} as |g|>


### PR DESCRIPTION

Before:
```hbs
<GMap @classNames="my-custom-class" />
```

After:
```hbs
<GMap class="my-custom-class" />
```