### PR TITLE
fix: resolve DocumentFragment errors in newer Ember versions

### DIFF
--- a/addon/components/g-map/control.js
+++ b/addon/components/g-map/control.js
@@ -7,7 +7,7 @@ export default class Control extends MapComponent {
   id = `ember-google-maps-control-${guidFor(this)}`;
 
   @tracked
-  container = window?.document?.createDocumentFragment();
+  container = window?.document?.createElement('div');
 
   // Keep track of the current control position so that it can be removed on
   // teardown

--- a/addon/components/g-map/overlay.js
+++ b/addon/components/g-map/overlay.js
@@ -9,7 +9,7 @@ export default class OverlayView extends MapComponent {
   id = `ember-google-maps-overlay-${guidFor(this)}`;
 
   @tracked
-  container = window?.document?.createDocumentFragment();
+  container = window?.document?.createElement('div');
 
   get name() {
     return 'overlays';


### PR DESCRIPTION
Glimmer doesn't seem to like DocumentFragment anymore. Replaced with a div element.