### PR TITLE
Deprecate Ember v3.24 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ ember install ember-google-maps
 --------------------------------------------------------------------------------
 
 ### [![Latest version][npm-version-badge]][npm-url]
-  - Ember.js v3.24 or above
-  - Ember CLI v3.24 or above
+  - Ember.js v3.28 or above
+  - Ember CLI v3.28 or above
   - Node.js v12 or above
 
 

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
   "ember-addon": {
     "configPath": "tests/dummy/config",
     "versionCompatibility": {
-      "ember": ">=3.24.0"
+      "ember": ">=3.28.0"
     },
     "demoURL": "https://ember-google-maps.sandydoo.me"
   },


### PR DESCRIPTION
The new minimum bound is v3.28. Older versions may work, but we don't test against them.