### PR TITLE
Update the official minimum Node version to >=v18

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ ember install ember-google-maps
 ### [![Latest version][npm-version-badge]][npm-url]
   - Ember.js v3.28 or above
   - Ember CLI v3.28 or above
-  - Node.js v12 or above
+  - Node.js v18 or above
 
 
 ⭐ Examples


### PR DESCRIPTION
Node versions v12.x, v14.x, and v16.x are all EOL. The addon likely works with all of these, but it will no longer be tested against them and compatibility moving forward is not guaranteed.