### PR TITLE
Add g-map/hash helper

### DIFF
--- a/addon/helpers/g-map/hash.js
+++ b/addon/helpers/g-map/hash.js
@@ -1,0 +1,5 @@
+import { helper } from '@ember/component/helper';
+
+export default helper(function gMapHash(positional, named) {
+  return { ...named };
+});

--- a/app/helpers/g-map/hash.js
+++ b/app/helpers/g-map/hash.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-google-maps/helpers/g-map/hash';

--- a/docs/app/templates/docs/controls.hbs
+++ b/docs/app/templates/docs/controls.hbs
@@ -3,7 +3,7 @@
     <section>
       <h5>Adding, removing and modifying map controls</h5>
 
-      <p>Recall that almost anything you pass to the component is passed on as an option to the map. The options for controls are no exception. You can add or remove specific controls by setting the corresponding control variable to <var>true</var> or <var>false</var>. You can also pass in a <var>hash</var> to set further options. Learn more by following the guides at <GoogleDocs @section="controls" @type="guides">Controls Guide</GoogleDocs>.</p>
+      <p>Recall that almost anything you pass to the component is passed on as an option to the map. The options for controls are no exception. You can add or remove specific controls by setting the corresponding control variable to <var>true</var> or <var>false</var>. You can also pass in a <var>g-map/hash</var> to set further options. Learn more by following the guides at <GoogleDocs @section="controls" @type="guides">Controls Guide</GoogleDocs>.</p>
 
       <p>Let’s disable the default UI, make sure that we display the zoom control and move it to the top left.</p>
 
@@ -44,7 +44,7 @@
       @styles={{this.primaryMapStyle}}
       @disableDefaultUI={{true}}
       @zoomControl={{true}}
-      @zoomControlOptions={{hash position=this.google.maps.ControlPosition.TOP_LEFT}}
+      @zoomControlOptions={{g-map/hash position=this.google.maps.ControlPosition.TOP_LEFT}}
       class="ember-google-map-responsive" as |g|>
 
       <g.marker @lat={{this.london.lat}} @lng={{this.london.lng}} />

--- a/docs/app/templates/docs/directions.hbs
+++ b/docs/app/templates/docs/directions.hbs
@@ -58,7 +58,7 @@
         <d.waypoint @location="Leather Lane" />
 
         <d.route
-          @polylineOptions={{hash
+          @polylineOptions={{g-map/hash
             strokeColor="green"
             strokeWeight=8
             strokeOpacity=0.7}} as |r|>

--- a/docs/app/templates/docs/map.hbs
+++ b/docs/app/templates/docs/map.hbs
@@ -19,7 +19,7 @@
 
       <CodeSnippet @name="map-passing-options.hbs" />
 
-      <p>You can also pass an <var>options</var> object, but note that <b>it will not be watched for changes</b>. You can use the <var>hash</var> helper instead if you need the options to be watched.</p>
+      <p>You can also pass an <var>options</var> object, but note that <b>it will not be watched for changes</b>. You can use the <var>g-map/hash</var> helper instead if you need the options to be watched.</p>
     </section>
     <section>
       <h5 id="map-instance">Accessing the map instance</h5>

--- a/docs/app/templates/examples/sweet-rentals.hbs
+++ b/docs/app/templates/examples/sweet-rentals.hbs
@@ -27,7 +27,7 @@
       @gestureHandling="greedy"
       @disableDefaultUI={{true}}
       @zoomControl={{true}}
-      @zoomControlOptions={{hash
+      @zoomControlOptions={{g-map/hash
         position=this.google.maps.ControlPosition.TOP_LEFT}}
       @fullscreenControl={{true}}
       @onceOnIdle={{this.saveBounds}}

--- a/docs/code-snippets/basic-routes.hbs
+++ b/docs/code-snippets/basic-routes.hbs
@@ -8,7 +8,7 @@
     @destination="Clerkenwell"
     @travelMode="WALKING" as |directions|>
 
-    <directions.route @polylineOptions={{hash strokeColor="green"}} />
+    <directions.route @polylineOptions={{g-map/hash strokeColor="green"}} />
 
   </map.directions>
 </GMap>

--- a/docs/code-snippets/complex-routes.hbs
+++ b/docs/code-snippets/complex-routes.hbs
@@ -12,7 +12,7 @@
     {{!-- Display the route returned by the directions query --}}
     <directions.route
       @draggable={{true}}
-      @polylineOptions={{hash
+      @polylineOptions={{g-map/hash
         strokeColor="green"
         strokeWeight=8
         strokeOpacity=0.7}} as |route|>

--- a/docs/code-snippets/recenter-map-control.hbs
+++ b/docs/code-snippets/recenter-map-control.hbs
@@ -5,7 +5,7 @@
   @disableDefaultUI={{true}}
   @mapTypeControl={{false}}
   @zoomControl={{true}}
-  @zoomControlOptions={{hash
+  @zoomControlOptions={{g-map/hash
     position=this.google.maps.ControlPosition.TOP_LEFT}} as |map|>
 
   <map.marker @lat={{this.london.lat}} @lng={{this.london.lng}} />

--- a/docs/code-snippets/show-hide-controls.hbs
+++ b/docs/code-snippets/show-hide-controls.hbs
@@ -4,5 +4,5 @@
   @zoom={{12}}
   @disableDefaultUI={{true}}
   @zoomControl={{true}}
-  @zoomControlOptions={{hash
+  @zoomControlOptions={{g-map/hash
     position=this.google.maps.ControlPosition.LEFT_CENTER}} />

--- a/docs/code-snippets/sweet-rentals-map.hbs
+++ b/docs/code-snippets/sweet-rentals-map.hbs
@@ -7,7 +7,7 @@
   @gestureHandling="greedy"
   @disableDefaultUI={{true}}
   @zoomControl={{true}}
-  @zoomControlOptions={{hash
+  @zoomControlOptions={{g-map/hash
     position=this.google.maps.ControlPosition.TOP_LEFT}}
   @fullscreenControl={{true}}
   @onceOnIdle={{this.saveBounds}}

--- a/tests/integration/components/g-map-test.js
+++ b/tests/integration/components/g-map-test.js
@@ -52,7 +52,7 @@ module('Integration | Component | g map', function (hooks) {
       <GMap
         @lat={{this.lat}}
         @lng={{this.lng}}
-        @options={{hash zoom=12 zoomControl=false}} />
+        @options={{g-map/hash zoom=12 zoomControl=false}} />
     `);
 
     let { map } = await this.waitForMap();
@@ -158,7 +158,7 @@ module('Integration | Component | g map', function (hooks) {
         @lng={{this.lng}}
         @zoom={{12}}
         @onClick={{this.onClick}}
-        @events={{hash onZoomChanged=this.onZoomChanged}} />
+        @events={{g-map/hash onZoomChanged=this.onZoomChanged}} />
     `);
 
     let { map } = await this.waitForMap();


### PR DESCRIPTION
This is a workaround to safely pass objects containing options to Google Maps. The object created by `hash` lacks a prototype chain and the map will sometimes try (and fail) to access common methods, like `hasAttribute`.

If you're passing options to any map component using `{{ hash ... }}`, replace it with `{{ g-map/hash ... }}`.

Resolves #174.