### PR TITLE
feat: use advanced marker in place of the standard marker

### DIFF
--- a/addon/components/g-map.js
+++ b/addon/components/g-map.js
@@ -7,6 +7,7 @@ import { registerMapInstance } from '../component-managers/map-component-manager
 
 import { waitFor } from '@ember/test-waiters';
 import { DEBUG } from '@glimmer/env';
+import { v4 as uuidv4 } from 'uuid';
 
 function GMapPublicAPI(source) {
   return {
@@ -39,6 +40,7 @@ export default class GMap extends MapComponent {
     if (!this.args.center) {
       this.options.center = toLatLng(this.args.lat, this.args.lng);
     }
+    this.options.mapId = uuidv4();
 
     return this.options;
   }

--- a/addon/components/g-map/marker.js
+++ b/addon/components/g-map/marker.js
@@ -15,6 +15,6 @@ export default class Marker extends TypicalMapComponent {
   }
 
   newMapComponent(options = {}) {
-    return new google.maps.Marker(options);
+    return new google.maps.marker.AdvancedMarkerElement(options);
   }
 }

--- a/addon/utils/options-and-events.js
+++ b/addon/utils/options-and-events.js
@@ -204,7 +204,11 @@ export function addEventListener(
   let isOnce = isOnceEvent(originalEventName);
 
   let nativeListener = (target, eventName, callback) => {
-    target.addEventListener(eventName, callback, { once: isOnce });
+    if (target?.nodeName === 'GMP-INTERNAL-AM') {
+      target.addListener(eventName, callback, { once: isOnce });
+    } else {
+      target.addEventListener(eventName, callback, { once: isOnce });
+    }
   };
   let addListener = isDom
     ? nativeListener

--- a/index.js
+++ b/index.js
@@ -360,8 +360,11 @@ module.exports = {
     }
 
     if (libraries && libraries.length) {
-      params.push('libraries=' + encodeURIComponent(libraries.join(',')));
+      if (!libraries.includes('marker')) libraries.push('marker');
+    } else {
+      libraries = ['marker'];
     }
+    params.push('libraries=' + encodeURIComponent(libraries.join(',')));
 
     if (region) {
       params.push('region=' + encodeURIComponent(region));

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "ember-concurrency": "^3.1.1",
     "ember-modifier": "^4.1.0",
     "lodash": "^4.17.21",
-    "tracked-maps-and-sets": "^3.0.2"
+    "tracked-maps-and-sets": "^3.0.2",
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.23.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ dependencies:
   tracked-maps-and-sets:
     specifier: ^3.0.2
     version: 3.0.2
+  uuid:
+    specifier: ^9.0.1
+    version: 9.0.1
 
 devDependencies:
   '@babel/eslint-parser':
@@ -12140,6 +12143,11 @@ packages:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     hasBin: true
     dev: true
+
+  /uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    hasBin: true
+    dev: false
 
   /uvu@0.5.6:
     resolution: {integrity: sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==}


### PR DESCRIPTION
Since the standard marker is [deprecated](https://developers.google.com/maps/documentation/javascript/advanced-markers/migration).