### PR TITLE
feat: add advanced markers

### DIFF
--- a/addon/components/g-map.hbs
+++ b/addon/components/g-map.hbs
@@ -7,6 +7,7 @@
     map=this.map
     canvas=Canvas
     marker=(component 'g-map/marker' getContext=this.getComponent)
+    advancedMarker=(component 'g-map/advanced-marker' getContext=this.getComponent)
     circle=(component 'g-map/circle' getContext=this.getComponent)
     rectangle=(component 'g-map/rectangle' getContext=this.getComponent)
     polyline=(component 'g-map/polyline' getContext=this.getComponent)

--- a/addon/components/g-map.js
+++ b/addon/components/g-map.js
@@ -1,7 +1,6 @@
 import MapComponent from './g-map/map-component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { isPresent } from '@ember/utils';
 
 import { toLatLng } from '../utils/helpers';
 import { registerMapInstance } from '../component-managers/map-component-manager';

--- a/addon/components/g-map.js
+++ b/addon/components/g-map.js
@@ -28,10 +28,6 @@ export default class GMap extends MapComponent {
 
   mapId = uuidv4();
 
-  constructor(owner, args, options, events) {
-    super(owner, args, options, events);
-  }
-
   get publicAPI() {
     return GMapPublicAPI(this);
   }

--- a/addon/components/g-map.js
+++ b/addon/components/g-map.js
@@ -27,9 +27,10 @@ export default class GMap extends MapComponent {
 
   components = new Set();
 
+  mapId = uuidv4();
+
   constructor(owner, args, options, events) {
     super(owner, args, options, events);
-    this.options.mapId ??= uuidv4();
   }
 
   get publicAPI() {
@@ -46,6 +47,8 @@ export default class GMap extends MapComponent {
     if (!this.args.center) {
       this.options.center = toLatLng(this.args.lat, this.args.lng);
     }
+
+    this.options.mapId ??= this.mapId;
 
     return this.options;
   }

--- a/addon/components/g-map.js
+++ b/addon/components/g-map.js
@@ -7,6 +7,7 @@ import { registerMapInstance } from '../component-managers/map-component-manager
 
 import { waitFor } from '@ember/test-waiters';
 import { DEBUG } from '@glimmer/env';
+import { v4 as uuidv4 } from 'uuid';
 
 function GMapPublicAPI(source) {
   return {
@@ -39,6 +40,7 @@ export default class GMap extends MapComponent {
     if (!this.args.center) {
       this.options.center = toLatLng(this.args.lat, this.args.lng);
     }
+    this.options.mapId = uuidv4();
 
     return this.options;
   }

--- a/addon/components/g-map.js
+++ b/addon/components/g-map.js
@@ -26,6 +26,11 @@ export default class GMap extends MapComponent {
 
   components = new Set();
 
+  constructor(owner, args, options, events) {
+    super(owner, args, options, events);
+    this.options.mapId = uuidv4();
+  }
+
   get publicAPI() {
     return GMapPublicAPI(this);
   }
@@ -40,7 +45,6 @@ export default class GMap extends MapComponent {
     if (!this.args.center) {
       this.options.center = toLatLng(this.args.lat, this.args.lng);
     }
-    this.options.mapId = uuidv4();
 
     return this.options;
   }

--- a/addon/components/g-map.js
+++ b/addon/components/g-map.js
@@ -1,6 +1,7 @@
 import MapComponent from './g-map/map-component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
+import { isPresent } from '@ember/utils';
 
 import { toLatLng } from '../utils/helpers';
 import { registerMapInstance } from '../component-managers/map-component-manager';
@@ -28,7 +29,7 @@ export default class GMap extends MapComponent {
 
   constructor(owner, args, options, events) {
     super(owner, args, options, events);
-    this.options.mapId = uuidv4();
+    this.options.mapId ??= uuidv4();
   }
 
   get publicAPI() {

--- a/addon/components/g-map/advanced-marker.hbs
+++ b/addon/components/g-map/advanced-marker.hbs
@@ -1,0 +1,2 @@
+{{yield (hash
+  infoWindow=(component "g-map/info-window" getContext=@getContext target=this.mapComponent))}}

--- a/addon/components/g-map/advanced-marker.js
+++ b/addon/components/g-map/advanced-marker.js
@@ -10,9 +10,6 @@ export default class AdvancedMarker extends TypicalMapComponent {
     if (!this.args.position) {
       this.options.position = toLatLng(this.args.lat, this.args.lng);
     }
-    if (this.args.draggable) {
-      this.options.gmpDraggable = this.args.draggable;
-    }
 
     return this.options;
   }
@@ -20,7 +17,6 @@ export default class AdvancedMarker extends TypicalMapComponent {
   update(mapComponent) {
     super.update(mapComponent);
     mapComponent.position = this.newOptions.position;
-    mapComponent.gmpDraggable = this.newOptions.gmpDraggable;
   }
 
   newMapComponent(options = {}) {

--- a/addon/components/g-map/advanced-marker.js
+++ b/addon/components/g-map/advanced-marker.js
@@ -15,8 +15,8 @@ export default class AdvancedMarker extends TypicalMapComponent {
   }
 
   update(mapComponent) {
-    super.update(mapComponent);
-    mapComponent.position = this.newOptions.position;
+    Object.assign(mapComponent, this.newOptions);
+    return mapComponent;
   }
 
   newMapComponent(options = {}) {

--- a/addon/components/g-map/advanced-marker.js
+++ b/addon/components/g-map/advanced-marker.js
@@ -1,7 +1,7 @@
 import TypicalMapComponent from './typical-map-component';
 import { toLatLng } from '../../utils/helpers';
 
-export default class Marker extends TypicalMapComponent {
+export default class AdvancedMarker extends TypicalMapComponent {
   get name() {
     return 'advanced-markers';
   }

--- a/addon/components/g-map/advanced-marker.js
+++ b/addon/components/g-map/advanced-marker.js
@@ -3,7 +3,7 @@ import { toLatLng } from '../../utils/helpers';
 
 export default class AdvancedMarker extends TypicalMapComponent {
   get name() {
-    return 'advanced-markers';
+    return 'advancedMarkers';
   }
 
   get newOptions() {

--- a/addon/components/g-map/advanced-marker.js
+++ b/addon/components/g-map/advanced-marker.js
@@ -10,6 +10,9 @@ export default class AdvancedMarker extends TypicalMapComponent {
     if (!this.args.position) {
       this.options.position = toLatLng(this.args.lat, this.args.lng);
     }
+    if (this.args.draggable) {
+      this.options.gmpDraggable = this.args.draggable;
+    }
 
     return this.options;
   }

--- a/addon/components/g-map/advanced-marker.js
+++ b/addon/components/g-map/advanced-marker.js
@@ -17,6 +17,12 @@ export default class AdvancedMarker extends TypicalMapComponent {
     return this.options;
   }
 
+  update(mapComponent) {
+    super.update(mapComponent);
+    mapComponent.position = this.newOptions.position;
+    mapComponent.gmpDraggable = this.newOptions.gmpDraggable;
+  }
+
   newMapComponent(options = {}) {
     return new google.maps.marker.AdvancedMarkerElement(options);
   }

--- a/addon/components/g-map/advanced-marker.js
+++ b/addon/components/g-map/advanced-marker.js
@@ -1,0 +1,20 @@
+import TypicalMapComponent from './typical-map-component';
+import { toLatLng } from '../../utils/helpers';
+
+export default class Marker extends TypicalMapComponent {
+  get name() {
+    return 'advanced-markers';
+  }
+
+  get newOptions() {
+    if (!this.args.position) {
+      this.options.position = toLatLng(this.args.lat, this.args.lng);
+    }
+
+    return this.options;
+  }
+
+  newMapComponent(options = {}) {
+    return new google.maps.marker.AdvancedMarkerElement(options);
+  }
+}

--- a/addon/components/g-map/map-component.js
+++ b/addon/components/g-map/map-component.js
@@ -30,7 +30,6 @@ export function MapComponentAPI(source) {
 
 export default class MapComponent {
   @tracked mapComponent;
-  @tracked options;
 
   boundEvents = [];
 

--- a/addon/components/g-map/map-component.js
+++ b/addon/components/g-map/map-component.js
@@ -30,6 +30,7 @@ export function MapComponentAPI(source) {
 
 export default class MapComponent {
   @tracked mapComponent;
+  @tracked options;
 
   boundEvents = [];
 

--- a/addon/utils/options-and-events.js
+++ b/addon/utils/options-and-events.js
@@ -206,9 +206,10 @@ export function addEventListener(
   let nativeListener = (target, eventName, callback) => {
     target.addEventListener(eventName, callback, { once: isOnce });
   };
-  let addListener = isDom && target?.nodeName !== 'GMP-INTERNAL-AM'
-    ? nativeListener
-    : google.maps.event[`addListener${isOnce ? 'Once' : ''}`];
+  let addListener =
+    isDom && target?.nodeName !== 'GMP-INTERNAL-AM'
+      ? nativeListener
+      : google.maps.event[`addListener${isOnce ? 'Once' : ''}`];
 
   let eventName = isOnce
     ? originalEventName.slice(6) // onceOn

--- a/addon/utils/options-and-events.js
+++ b/addon/utils/options-and-events.js
@@ -206,7 +206,7 @@ export function addEventListener(
   let nativeListener = (target, eventName, callback) => {
     target.addEventListener(eventName, callback, { once: isOnce });
   };
-  let addListener = isDom
+  let addListener = isDom && target?.nodeName !== 'GMP-INTERNAL-AM'
     ? nativeListener
     : google.maps.event[`addListener${isOnce ? 'Once' : ''}`];
 

--- a/app/components/g-map/advanced-marker.js
+++ b/app/components/g-map/advanced-marker.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-google-maps/components/g-map/advanced-marker';

--- a/docs/app/components/code-snippet.js
+++ b/docs/app/components/code-snippet.js
@@ -28,7 +28,11 @@ export default class CodeSnippet extends Component {
 
   get code() {
     let grammar = Prism.languages[this.language];
-    let highlightedCode = Prism.highlight(this.snippet.source, grammar, this.language);
+    let highlightedCode = Prism.highlight(
+      this.snippet.source,
+      grammar,
+      this.language,
+    );
     return htmlSafe(highlightedCode);
   }
 }

--- a/docs/app/controllers/docs.js
+++ b/docs/app/controllers/docs.js
@@ -65,6 +65,7 @@ export default class DocsController extends ApplicationController {
     { title: 'Components', path: 'docs.components' },
     { title: 'Canvas', path: 'docs.canvas' },
     { title: 'Markers', path: 'docs.markers' },
+    { title: 'Advanced Markers', path: 'docs.advanced-markers' },
     { title: 'Circles', path: 'docs.circles', text: 'On to circles!' },
     { title: 'Polylines', path: 'docs.polylines', text: 'Onto polylines!' },
     {

--- a/docs/app/controllers/docs.js
+++ b/docs/app/controllers/docs.js
@@ -83,10 +83,7 @@ export default class DocsController extends ApplicationController {
       path: 'docs.directions',
       text: 'Let’s look at how to query and display routing information.',
     },
-    { title: 'Transit layers',
-      path: 'docs.transit-layers',
-      text: '',
-    },
+    { title: 'Transit layers', path: 'docs.transit-layers', text: '' },
     {
       title: 'Custom overlays',
       path: 'docs.overlays',

--- a/docs/app/controllers/docs/transit-layers.js
+++ b/docs/app/controllers/docs/transit-layers.js
@@ -1,30 +1,30 @@
- import DocsController from '../docs';
- import { tracked } from '@glimmer/tracking';
- import { action } from '@ember/object';
+import DocsController from '../docs';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
 
 export default class DocsTransitLayersController extends DocsController {
-   queryParams = ['layer'];
+  queryParams = ['layer'];
 
-   @tracked layer = 'traffic';
+  @tracked layer = 'traffic';
 
-   @action
-   switchLayer(newLayer) {
-     this.layer = newLayer;
-   }
+  @action
+  switchLayer(newLayer) {
+    this.layer = newLayer;
+  }
 
-   get codeSnippet() {
-     return `basic-${this.layer}-layer.hbs`;
-   }
+  get codeSnippet() {
+    return `basic-${this.layer}-layer.hbs`;
+  }
 
-   get isTrafficLayer() {
-     return this.layer === 'traffic';
-   }
+  get isTrafficLayer() {
+    return this.layer === 'traffic';
+  }
 
-   get isTransitLayer() {
-     return this.layer === 'transit';
-   }
+  get isTransitLayer() {
+    return this.layer === 'transit';
+  }
 
-   get isBicyclingLayer() {
-     return this.layer === 'bicycling';
-   }
- }
+  get isBicyclingLayer() {
+    return this.layer === 'bicycling';
+  }
+}

--- a/docs/app/router.js
+++ b/docs/app/router.js
@@ -26,6 +26,7 @@ Router.map(function () {
     this.route('components');
     this.route('canvas');
     this.route('markers');
+    this.route('advanced-markers');
     this.route('circles');
     this.route('polylines');
     this.route('info-windows');

--- a/docs/app/routes/docs/advanced-markers.js
+++ b/docs/app/routes/docs/advanced-markers.js
@@ -1,0 +1,5 @@
+import Route from '@ember/routing/route';
+
+export default class extends Route {
+  controllerName = 'docs';
+}

--- a/docs/app/templates/docs/advanced-markers.hbs
+++ b/docs/app/templates/docs/advanced-markers.hbs
@@ -1,0 +1,42 @@
+<div class="row">
+  <div class="col-lg-7 order-2 order-lg-1">
+    <section>
+      <h5 id="markers">Creating advanced markers</h5>
+
+      <p>You can create an advanced marker with the yielded <var>advancedMarker</var> component. Once again, you can use either <var>lat</var> and <var>lng</var>, or <var>position</var>, to set the position.</p>
+
+      <p>Every attribute passed to <var>advancedMarker</var> will be passed on as an option to the advanced marker, much like with the <var>marker</var> component. Events work in the same way.</p>
+
+      <DocTip>
+        Don’t forget that these are Google Maps events, not Ember events! <LinkTo @route="docs.map">Learn about event handling ›</LinkTo>
+      </DocTip>
+
+      <CodeSnippet @name="advanced-markers.hbs" />
+
+      <DocTip @badgeText="Test">
+        Click on a marker to find out its coordinates.
+      </DocTip>
+    </section>
+
+    <p>{{this.nextPage.text}}</p>
+    <LinkToNext @nextPage={{this.nextPage}} />
+  </div>
+  <div class="col-lg-5 order-1 order-lg-2 sticky-top sticky-map">
+    <GMap
+      @lat={{this.london.lat}}
+      @lng={{this.london.lng}}
+      @zoom={{12}}
+      @styles={{this.primaryMapStyle}}
+      class="ember-google-map-responsive" as |g|>
+
+      {{#each-in this.locations key="id" as |id location|}}
+        <g.marker
+          @lat={{location.lat}}
+          @lng={{location.lng}}
+          @visible={{true}}
+          @draggable={{false}}
+          @onClick={{fn this.flashMessage (concat "Clicked: " location.lat ", " location.lng)}} />
+      {{/each-in}}
+    </GMap>
+  </div>
+</div>

--- a/docs/app/templates/docs/advanced-markers.hbs
+++ b/docs/app/templates/docs/advanced-markers.hbs
@@ -3,6 +3,8 @@
     <section>
       <h5 id="markers">Creating advanced markers</h5>
 
+      <p>We encourage you to transition to these new Advanced Markers. Advanced markers provide substantial improvements over the legacy Marker class.</p>
+
       <p>You can create an advanced marker with the yielded <var>advancedMarker</var> component. Once again, you can use either <var>lat</var> and <var>lng</var>, or <var>position</var>, to set the position.</p>
 
       <p>Every attribute passed to <var>advancedMarker</var> will be passed on as an option to the advanced marker, much like with the <var>marker</var> component. Events work in the same way.</p>
@@ -30,11 +32,10 @@
       class="ember-google-map-responsive" as |g|>
 
       {{#each-in this.locations key="id" as |id location|}}
-        <g.marker
+        <g.advancedMarker
           @lat={{location.lat}}
           @lng={{location.lng}}
-          @visible={{true}}
-          @draggable={{false}}
+          @gmpDraggable={{false}}
           @onClick={{fn this.flashMessage (concat "Clicked: " location.lat ", " location.lng)}} />
       {{/each-in}}
     </GMap>

--- a/docs/app/templates/docs/markers.hbs
+++ b/docs/app/templates/docs/markers.hbs
@@ -3,6 +3,8 @@
     <section>
       <h5 id="markers">Creating markers</h5>
 
+      <p>⚠️Note: As of February 21st, 2024 (v3.56), Marker is deprecated and <LinkTo @route="docs.advanced-markers" >Advanced Marker</LinkTo> is now preferred over marker.</p>
+
       <p>You can create a basic marker with the yielded <var>marker</var> component. Once again, you can use either <var>lat</var> and <var>lng</var>, or <var>position</var>, to set the position.</p>
 
       <p>Every attribute passed to the marker will be passed on as an option to the marker, much like with the <var>g-map</var> component. Events work in the same way.</p>

--- a/docs/code-snippets/advanced-markers.hbs
+++ b/docs/code-snippets/advanced-markers.hbs
@@ -7,7 +7,7 @@
     <map.advancedMarker
       @lat={{location.lat}}
       @lng={{location.lng}}
-      @draggable={{true}}
+      @gmpDraggable={{true}}
       @onClick={{this.onClick}} />
   {{/each}}
 

--- a/docs/code-snippets/advanced-markers.hbs
+++ b/docs/code-snippets/advanced-markers.hbs
@@ -1,0 +1,14 @@
+<GMap
+  @lat="51.507568"
+  @lng="-0.127762"
+  @zoom={{9}} as |map|>
+
+  {{#each this.londonLocations as |location|}}
+    <map.advancedMarker
+      @lat={{location.lat}}
+      @lng={{location.lng}}
+      @draggable={{true}}
+      @onClick={{this.onClick}} />
+  {{/each}}
+
+</GMap>

--- a/docs/config/environment.js
+++ b/docs/config/environment.js
@@ -30,7 +30,7 @@ module.exports = function (environment) {
 
     'ember-google-maps': {
       language: 'en',
-      libraries: ['geometry', 'places'],
+      libraries: ['geometry', 'places', 'marker'],
       key: process.env.GOOGLE_MAPS_API_KEY,
     },
   };

--- a/docs/ember-cli-build.js
+++ b/docs/ember-cli-build.js
@@ -41,6 +41,7 @@ module.exports = function (defaults) {
         '/docs/components',
         '/docs/canvas',
         '/docs/markers',
+        '/docs/advanced-markers',
         '/docs/circles',
         '/docs/polylines',
         '/docs/info-windows',

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -130,7 +130,7 @@ devDependencies:
     version: file:..(ember-source@5.5.0)(webpack@5.89.0)
   ember-google-maps-markerclustererplus:
     specifier: ^1.0.1
-    version: 1.0.1(@babel/core@7.23.6)(ember-google-maps@7.0.0)(webpack@5.89.0)
+    version: 1.0.1(@babel/core@7.23.6)(ember-google-maps@7.1.0)(webpack@5.89.0)
   ember-load-initializers:
     specifier: ^2.1.2
     version: 2.1.2(@babel/core@7.23.6)
@@ -6703,7 +6703,7 @@ packages:
       - supports-color
     dev: true
 
-  /ember-google-maps-markerclustererplus@1.0.1(@babel/core@7.23.6)(ember-google-maps@7.0.0)(webpack@5.89.0):
+  /ember-google-maps-markerclustererplus@1.0.1(@babel/core@7.23.6)(ember-google-maps@7.1.0)(webpack@5.89.0):
     resolution: {integrity: sha512-vPLNBI7klqsCChbQvrvRoP5VmNB5hkMtrW9RqBXPlnAf/+42F/ZlkxfsXHWotanWnH/jkhZnOGb8DnhUdU22bw==}
     engines: {node: 10.* || >= 12}
     peerDependencies:
@@ -13182,6 +13182,11 @@ packages:
     hasBin: true
     dev: true
 
+  /uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    hasBin: true
+    dev: true
+
   /v8-compile-cache@2.4.0:
     resolution: {integrity: sha512-ocyWc3bAHBB/guyqJQVI5o4BZkPhznPYUG2ea80Gond/BgNWpap8TOmLSeeQG7bnh2KMISxskdADG59j7zruhw==}
     dev: true
@@ -13692,9 +13697,9 @@ packages:
       ember-cli-version-checker: 5.1.2
       ember-concurrency: 3.1.1(@babel/core@7.23.6)(ember-source@5.5.0)
       ember-modifier: 4.1.0(ember-source@5.5.0)
-      ember-source: 5.5.0(@babel/core@7.23.6)(@glimmer/component@1.1.2)(rsvp@4.8.5)(webpack@5.89.0)
       lodash: 4.17.21
       tracked-maps-and-sets: 3.0.2
+      uuid: 9.0.1
     transitivePeerDependencies:
       - '@glint/template'
       - ember-source

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,1 +1,13 @@
-{"compilerOptions":{"target":"es6","experimentalDecorators":true},"exclude":["node_modules","bower_components","tmp","vendor",".git","dist"]}
+{
+  "compilerOptions": {
+    "target": "es2021",
+    "experimentalDecorators":true
+  },
+  "exclude": [
+    "node_modules",
+    "tmp",
+    "vendor",
+    ".git",
+    "dist"
+  ]
+}

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,13 +1,1 @@
-{
-  "compilerOptions": {
-    "target": "es2021",
-    "experimentalDecorators":true
-  },
-  "exclude": [
-    "node_modules",
-    "tmp",
-    "vendor",
-    ".git",
-    "dist"
-  ]
-}
+{"compilerOptions":{"target":"es6","experimentalDecorators":true},"exclude":["node_modules","bower_components","tmp","vendor",".git","dist"]}

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "ember-concurrency": "^3.1.1",
     "ember-modifier": "^4.1.0",
     "lodash": "^4.17.21",
-    "tracked-maps-and-sets": "^3.0.2"
+    "tracked-maps-and-sets": "^3.0.2",
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.23.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ dependencies:
   tracked-maps-and-sets:
     specifier: ^3.0.2
     version: 3.0.2
+  uuid:
+    specifier: ^9.0.1
+    version: 9.0.1
 
 devDependencies:
   '@babel/eslint-parser':
@@ -12140,6 +12143,11 @@ packages:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     hasBin: true
     dev: true
+
+  /uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    hasBin: true
+    dev: false
 
   /uvu@0.5.6:
     resolution: {integrity: sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==}

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -21,7 +21,7 @@ module.exports = function (environment) {
 
     'ember-google-maps': {
       language: 'en',
-      libraries: ['geometry', 'places'],
+      libraries: ['geometry', 'places', 'marker'],
       key: process.env.GOOGLE_MAPS_API_KEY,
     },
   };

--- a/tests/integration/components/g-map/advanced-marker-test.js
+++ b/tests/integration/components/g-map/advanced-marker-test.js
@@ -121,6 +121,9 @@ module('Integration | Component | g map/advanced-marker', function (hooks) {
 
     let newPosition = new google.maps.LatLng(advancedMarker.position);
 
-    assert.ok(newLatLng.equals(newPosition), 'advanced marker position updated');
+    assert.ok(
+      newLatLng.equals(newPosition),
+      'advanced marker position updated',
+    );
   });
 });

--- a/tests/integration/components/g-map/advanced-marker-test.js
+++ b/tests/integration/components/g-map/advanced-marker-test.js
@@ -52,7 +52,7 @@ module('Integration | Component | g map/advanced-marker', function (hooks) {
   test('it sets options on an advanced marker', async function (assert) {
     await render(hbs`
       <GMap @lat={{this.lat}} @lng={{this.lng}} as |g|>
-        <g.advancedMarker @lat={{this.lat}} @lng={{this.lng}} @draggable={{true}} />
+        <g.advancedMarker @lat={{this.lat}} @lng={{this.lng}} @gmpDraggable={{true}} />
       </GMap>
     `);
 
@@ -73,7 +73,7 @@ module('Integration | Component | g map/advanced-marker', function (hooks) {
     await render(hbs`
       <GMap @lat={{this.lat}} @lng={{this.lng}} as |g|>
         {{#if this.showMarker}}
-          <g.advancedMarker @lat={{this.lat}} @lng={{this.lng}} @draggable={{true}} />
+          <g.advancedMarker @lat={{this.lat}} @lng={{this.lng}} @gmpDraggable={{true}} />
         {{/if}}
       </GMap>
     `);

--- a/tests/integration/components/g-map/advanced-marker-test.js
+++ b/tests/integration/components/g-map/advanced-marker-test.js
@@ -20,7 +20,7 @@ module('Integration | Component | g map/advanced-marker', function (hooks) {
 
     let {
       map,
-      components: { advancedMarkers },
+      components: { 'advanced-markers': advancedMarkers },
     } = await this.waitForMap();
 
     let advancedMarker = advancedMarkers[0].mapComponent;
@@ -41,7 +41,7 @@ module('Integration | Component | g map/advanced-marker', function (hooks) {
     `);
 
     let {
-      components: { advancedMarkers },
+      components: { 'advanced-markers': advancedMarkers },
     } = await this.waitForMap();
 
     let advancedMarker = advancedMarkers[0].mapComponent;
@@ -57,12 +57,12 @@ module('Integration | Component | g map/advanced-marker', function (hooks) {
     `);
 
     let {
-      components: { advancedMarkers },
+      components: { 'advanced-markers': advancedMarkers },
     } = await this.waitForMap();
 
     let advancedMarker = advancedMarkers[0].mapComponent;
 
-    assert.true(advancedMarker.draggable);
+    assert.true(advancedMarker.gmpDraggable);
   });
 
   test('it unregisters an advanced marker on teardown', async function (assert) {
@@ -79,7 +79,7 @@ module('Integration | Component | g map/advanced-marker', function (hooks) {
     `);
 
     let {
-      components: { advancedMarkers },
+      components: { 'advanced-markers': advancedMarkers },
     } = await this.waitForMap();
 
     assert.strictEqual(advancedMarkers.length, 1, 'advanced marker registered');
@@ -107,7 +107,7 @@ module('Integration | Component | g map/advanced-marker', function (hooks) {
 
     let newLatLng = google.maps.geometry.spherical.computeOffset(
       toLatLng(this.markerLat, this.markerLng),
-      500,
+      5000,
       0,
     );
 
@@ -117,10 +117,16 @@ module('Integration | Component | g map/advanced-marker', function (hooks) {
     });
 
     let { components } = await this.waitForMap();
-    let advancedMarker = components.advancedMarkers[0].mapComponent;
+    let advancedMarker = components['advanced-markers'][0].mapComponent;
+
+    let newPosition = advancedMarker.position;
+
+    let isLatSame = newLatLng.lat() === newPosition.lat;
+    let isLngSame = newLatLng.lng() === newPosition.lng;
+    let isLatLngSame = isLatSame && isLngSame;
 
     assert.ok(
-      newLatLng.equals(advancedMarker.getPosition()),
+      isLatLngSame,
       'advanced marker position updated',
     );
   });

--- a/tests/integration/components/g-map/advanced-marker-test.js
+++ b/tests/integration/components/g-map/advanced-marker-test.js
@@ -1,0 +1,127 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { setupMapTest, trigger } from 'ember-google-maps/test-support';
+import { setupLocations } from 'dummy/tests/helpers/locations';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import { toLatLng } from 'ember-google-maps/utils/helpers';
+
+module('Integration | Component | g map/advanced-marker', function (hooks) {
+  setupRenderingTest(hooks);
+  setupMapTest(hooks);
+  setupLocations(hooks);
+
+  test('it renders an advanced-marker', async function (assert) {
+    await render(hbs`
+      <GMap @lat={{this.lat}} @lng={{this.lng}} as |g|>
+        <g.advancedMarker @lat={{this.lat}} @lng={{this.lng}} />
+      </GMap>
+    `);
+
+    let {
+      map,
+      components: { advancedMarkers },
+    } = await this.waitForMap();
+
+    let advancedMarker = advancedMarkers[0].mapComponent;
+
+    assert.strictEqual(advancedMarkers.length, 1);
+    assert.deepEqual(advancedMarker.map, map);
+  });
+
+  test('it attaches an event to an advanced marker', async function (assert) {
+    assert.expect(1);
+
+    this.onClick = () => assert.ok('It binds events to actions');
+
+    await render(hbs`
+      <GMap @lat={{this.lat}} @lng={{this.lng}} as |g|>
+        <g.advancedMarker @lat={{this.lat}} @lng={{this.lng}} @onClick={{this.onClick}} />
+      </GMap>
+    `);
+
+    let {
+      components: { advancedMarkers },
+    } = await this.waitForMap();
+
+    let advancedMarker = advancedMarkers[0].mapComponent;
+
+    trigger(advancedMarker, 'click');
+  });
+
+  test('it sets options on an advanced marker', async function (assert) {
+    await render(hbs`
+      <GMap @lat={{this.lat}} @lng={{this.lng}} as |g|>
+        <g.advancedMarker @lat={{this.lat}} @lng={{this.lng}} @draggable={{true}} />
+      </GMap>
+    `);
+
+    let {
+      components: { advancedMarkers },
+    } = await this.waitForMap();
+
+    let advancedMarker = advancedMarkers[0].mapComponent;
+
+    assert.true(advancedMarker.draggable);
+  });
+
+  test('it unregisters an advanced marker on teardown', async function (assert) {
+    assert.expect(2);
+
+    this.set('showMarker', true);
+
+    await render(hbs`
+      <GMap @lat={{this.lat}} @lng={{this.lng}} as |g|>
+        {{#if this.showMarker}}
+          <g.advancedMarker @lat={{this.lat}} @lng={{this.lng}} @draggable={{true}} />
+        {{/if}}
+      </GMap>
+    `);
+
+    let {
+      components: { advancedMarkers },
+    } = await this.waitForMap();
+
+    assert.strictEqual(advancedMarkers.length, 1, 'advanced marker registered');
+
+    this.set('showMarker', false);
+    await this.waitForMap();
+
+    // This tests makes sure that the markers array is updated.
+    assert.strictEqual(advancedMarkers.length, 0, 'marker unregistered');
+  });
+
+  test('it updates the advanced marker’s position', async function (assert) {
+    this.setProperties({
+      markerLat: this.lat,
+      markerLng: this.lng,
+    });
+
+    await render(hbs`
+      <GMap @lat={{this.lat}} @lng={{this.lng}} as |g|>
+        <g.advancedMarker @lat={{this.markerLat}} @lng={{this.markerLng}}/>
+      </GMap>
+    `);
+
+    await this.waitForMap();
+
+    let newLatLng = google.maps.geometry.spherical.computeOffset(
+      toLatLng(this.markerLat, this.markerLng),
+      500,
+      0,
+    );
+
+    this.setProperties({
+      markerLat: newLatLng.lat(),
+      markerLng: newLatLng.lng(),
+    });
+
+    let { components } = await this.waitForMap();
+    let advancedMarker = components.advancedMarkers[0].mapComponent;
+
+    assert.ok(
+      newLatLng.equals(advancedMarker.getPosition()),
+      'advanced marker position updated',
+    );
+  });
+});

--- a/tests/integration/components/g-map/advanced-marker-test.js
+++ b/tests/integration/components/g-map/advanced-marker-test.js
@@ -119,12 +119,8 @@ module('Integration | Component | g map/advanced-marker', function (hooks) {
     let { components } = await this.waitForMap();
     let advancedMarker = components.advancedMarkers[0].mapComponent;
 
-    let newPosition = advancedMarker.position;
+    let newPosition = new google.maps.LatLng(advancedMarker.position);
 
-    let isLatSame = newLatLng.lat() === newPosition.lat;
-    let isLngSame = newLatLng.lng() === newPosition.lng;
-    let isLatLngSame = isLatSame && isLngSame;
-
-    assert.ok(isLatLngSame, 'advanced marker position updated');
+    assert.ok(newLatLng.equals(newPosition), 'advanced marker position updated');
   });
 });

--- a/tests/integration/components/g-map/advanced-marker-test.js
+++ b/tests/integration/components/g-map/advanced-marker-test.js
@@ -125,9 +125,6 @@ module('Integration | Component | g map/advanced-marker', function (hooks) {
     let isLngSame = newLatLng.lng() === newPosition.lng;
     let isLatLngSame = isLatSame && isLngSame;
 
-    assert.ok(
-      isLatLngSame,
-      'advanced marker position updated',
-    );
+    assert.ok(isLatLngSame, 'advanced marker position updated');
   });
 });

--- a/tests/integration/components/g-map/advanced-marker-test.js
+++ b/tests/integration/components/g-map/advanced-marker-test.js
@@ -20,7 +20,7 @@ module('Integration | Component | g map/advanced-marker', function (hooks) {
 
     let {
       map,
-      components: { 'advanced-markers': advancedMarkers },
+      components: { advancedMarkers },
     } = await this.waitForMap();
 
     let advancedMarker = advancedMarkers[0].mapComponent;
@@ -41,7 +41,7 @@ module('Integration | Component | g map/advanced-marker', function (hooks) {
     `);
 
     let {
-      components: { 'advanced-markers': advancedMarkers },
+      components: { advancedMarkers },
     } = await this.waitForMap();
 
     let advancedMarker = advancedMarkers[0].mapComponent;
@@ -57,7 +57,7 @@ module('Integration | Component | g map/advanced-marker', function (hooks) {
     `);
 
     let {
-      components: { 'advanced-markers': advancedMarkers },
+      components: { advancedMarkers },
     } = await this.waitForMap();
 
     let advancedMarker = advancedMarkers[0].mapComponent;
@@ -79,7 +79,7 @@ module('Integration | Component | g map/advanced-marker', function (hooks) {
     `);
 
     let {
-      components: { 'advanced-markers': advancedMarkers },
+      components: { advancedMarkers },
     } = await this.waitForMap();
 
     assert.strictEqual(advancedMarkers.length, 1, 'advanced marker registered');
@@ -117,7 +117,7 @@ module('Integration | Component | g map/advanced-marker', function (hooks) {
     });
 
     let { components } = await this.waitForMap();
-    let advancedMarker = components['advanced-markers'][0].mapComponent;
+    let advancedMarker = components.advancedMarkers[0].mapComponent;
 
     let newPosition = advancedMarker.position;
 

--- a/tests/integration/components/g-map/info-window-test.js
+++ b/tests/integration/components/g-map/info-window-test.js
@@ -111,11 +111,11 @@ module('Integration | Component | g-map/info-window', function (hooks) {
   test('it attaches an info window to a marker', async function (assert) {
     await render(hbs`
       <GMap @lat={{this.lat}} @lng={{this.lng}} @zoom={{6}} as |g|>
-        <g.advancedMarker @lat={{55}} @lng={{2}} as |m|>
+        <g.marker @lat={{55}} @lng={{2}} as |m|>
           <m.infoWindow
             @isOpen={{true}}
             @content="Testing info windows attached to markers" />
-        </g.advancedMarker>
+        </g.marker>
       </GMap>
     `);
 
@@ -132,18 +132,19 @@ module('Integration | Component | g-map/info-window', function (hooks) {
 
     await render(hbs`
       <GMap @lat={{this.lat}} @lng={{this.lng}} @zoom={{6}} as |g|>
-        <g.advancedMarker @lat={{55}} @lng={{2}} as |m|>
+        <g.marker @lat={{55}} @lng={{2}} as |m|>
           <m.infoWindow
             @isOpen={{this.isOpen}}>
             <div id="info-window-test">
               An info window attached to a marker!
             </div>
           </m.infoWindow>
-        </g.advancedMarker>
+        </g.marker>
       </GMap>
   `);
 
     let infoWindow = await this.getFirstInfoWindow();
+    await waitUntil(() => isVisible(infoWindow));
 
     assert.ok(find('#info-window-test'));
     assert.ok(isVisible(infoWindow));
@@ -166,18 +167,19 @@ module('Integration | Component | g-map/info-window', function (hooks) {
 
     await render(hbs`
       <GMap @lat={{this.lat}} @lng={{this.lng}} @zoom={{6}} as |g|>
-        <g.advancedMarker @lat={{55}} @lng={{2}} as |m|>
+        <g.marker @lat={{55}} @lng={{2}} as |m|>
           <m.infoWindow
             @isOpen={{this.isOpen}}
             @onCloseclick={{this.closeInfoWindow}}
             @content="<div id='info-window-test'>Testing the close button!</div>"/>
-        </g.advancedMarker>
+        </g.marker>
       </GMap>
     `);
 
     let infoWindow = await this.getFirstInfoWindow();
 
     assert.ok(find('#info-window-test'));
+    await waitUntil(() => isVisible(infoWindow));
     assert.ok(isVisible(infoWindow), 'info window is visible');
 
     trigger(infoWindow, 'closeclick');

--- a/tests/integration/components/g-map/info-window-test.js
+++ b/tests/integration/components/g-map/info-window-test.js
@@ -111,11 +111,11 @@ module('Integration | Component | g-map/info-window', function (hooks) {
   test('it attaches an info window to a marker', async function (assert) {
     await render(hbs`
       <GMap @lat={{this.lat}} @lng={{this.lng}} @zoom={{6}} as |g|>
-        <g.marker @lat={{55}} @lng={{2}} as |m|>
+        <g.advancedMarker @lat={{55}} @lng={{2}} as |m|>
           <m.infoWindow
             @isOpen={{true}}
             @content="Testing info windows attached to markers" />
-        </g.marker>
+        </g.advancedMarker>
       </GMap>
     `);
 
@@ -132,16 +132,16 @@ module('Integration | Component | g-map/info-window', function (hooks) {
 
     await render(hbs`
       <GMap @lat={{this.lat}} @lng={{this.lng}} @zoom={{6}} as |g|>
-        <g.marker @lat={{55}} @lng={{2}} as |m|>
+        <g.advancedMarker @lat={{55}} @lng={{2}} as |m|>
           <m.infoWindow
             @isOpen={{this.isOpen}}>
             <div id="info-window-test">
               An info window attached to a marker!
             </div>
           </m.infoWindow>
-        </g.marker>
+        </g.advancedMarker>
       </GMap>
-    `);
+  `);
 
     let infoWindow = await this.getFirstInfoWindow();
 
@@ -166,12 +166,12 @@ module('Integration | Component | g-map/info-window', function (hooks) {
 
     await render(hbs`
       <GMap @lat={{this.lat}} @lng={{this.lng}} @zoom={{6}} as |g|>
-        <g.marker @lat={{55}} @lng={{2}} as |m|>
+        <g.advancedMarker @lat={{55}} @lng={{2}} as |m|>
           <m.infoWindow
             @isOpen={{this.isOpen}}
             @onCloseclick={{this.closeInfoWindow}}
             @content="<div id='info-window-test'>Testing the close button!</div>"/>
-        </g.marker>
+        </g.advancedMarker>
       </GMap>
     `);
 


### PR DESCRIPTION
Since the standard marker is [deprecated](https://developers.google.com/maps/documentation/javascript/advanced-markers/migration).