### PR TITLE
Remove default mapId from the map

### DIFF
--- a/addon/components/g-map.js
+++ b/addon/components/g-map.js
@@ -7,7 +7,6 @@ import { registerMapInstance } from '../component-managers/map-component-manager
 
 import { waitFor } from '@ember/test-waiters';
 import { DEBUG } from '@glimmer/env';
-import { v4 as uuidv4 } from 'uuid';
 
 function GMapPublicAPI(source) {
   return {
@@ -26,8 +25,6 @@ export default class GMap extends MapComponent {
 
   components = new Set();
 
-  mapId = uuidv4();
-
   get publicAPI() {
     return GMapPublicAPI(this);
   }
@@ -42,8 +39,6 @@ export default class GMap extends MapComponent {
     if (!this.args.center) {
       this.options.center = toLatLng(this.args.lat, this.args.lng);
     }
-
-    this.options.mapId ??= this.mapId;
 
     return this.options;
   }

--- a/docs/app/controllers/docs.js
+++ b/docs/app/controllers/docs.js
@@ -45,6 +45,8 @@ export default class DocsController extends ApplicationController {
   primaryMapStyle = darkStyle;
   lightStyle = lightStyle;
 
+  mapId = "424eeb45d82b93bd";
+
   get currentPage() {
     return this.links.find((l) => l.path === this.routeName);
   }

--- a/docs/app/templates/docs/advanced-markers.hbs
+++ b/docs/app/templates/docs/advanced-markers.hbs
@@ -3,7 +3,11 @@
     <section>
       <h5 id="markers">Creating advanced markers</h5>
 
-      <p>The <GoogleDocs @section="advanced-markers">Advanced Marker</GoogleDocs> is Google Maps' successor to the <GoogleDocs @section="marker">Marker</GoogleDocs>.</p>
+      <p>
+        The <GoogleDocs @section="advanced-markers">Advanced Marker</GoogleDocs> is Google Maps' successor to the <GoogleDocs @section="marker">Marker</GoogleDocs>.
+        To use the advanced markers, the map must have a <GoogleDocs @type="guide" @section="get-map-id"><var>mapId</var></GoogleDocs>.
+        Legacy styling with <var>styles</var> will also be disabled.
+      </p>
 
       <p>You can create an advanced marker with the yielded <var>advancedMarker</var> component. You can use either <var>lat</var> and <var>lng</var>, or <var>position</var>, to set the position.</p>
 
@@ -28,8 +32,7 @@
       @lat={{this.london.lat}}
       @lng={{this.london.lng}}
       @zoom={{12}}
-      @styles={{this.primaryMapStyle}}
-      @mapId="ember-google-maps"
+      @mapId={{this.mapId}}
       class="ember-google-map-responsive" as |g|>
 
       {{#each-in this.locations key="id" as |id location|}}

--- a/docs/app/templates/docs/advanced-markers.hbs
+++ b/docs/app/templates/docs/advanced-markers.hbs
@@ -3,11 +3,11 @@
     <section>
       <h5 id="markers">Creating advanced markers</h5>
 
-      <p>We encourage you to transition to these new Advanced Markers. Advanced markers provide substantial improvements over the legacy Marker class.</p>
+      <p>The <GoogleDocs @section="advanced-markers">Advanced Marker</GoogleDocs> is Google Maps' successor to the <GoogleDocs @section="marker">Marker</GoogleDocs>.</p>
 
-      <p>You can create an advanced marker with the yielded <var>advancedMarker</var> component. Once again, you can use either <var>lat</var> and <var>lng</var>, or <var>position</var>, to set the position.</p>
+      <p>You can create an advanced marker with the yielded <var>advancedMarker</var> component. You can use either <var>lat</var> and <var>lng</var>, or <var>position</var>, to set the position.</p>
 
-      <p>Every attribute passed to <var>advancedMarker</var> will be passed on as an option to the advanced marker, much like with the <var>marker</var> component. Events work in the same way.</p>
+      <p>Every attribute passed to <var>advancedMarker</var> will be passed on as an option to the advanced marker.</p>
 
       <DocTip>
         Don’t forget that these are Google Maps events, not Ember events! <LinkTo @route="docs.map">Learn about event handling ›</LinkTo>

--- a/docs/app/templates/docs/advanced-markers.hbs
+++ b/docs/app/templates/docs/advanced-markers.hbs
@@ -29,6 +29,7 @@
       @lng={{this.london.lng}}
       @zoom={{12}}
       @styles={{this.primaryMapStyle}}
+      @mapId="ember-google-maps"
       class="ember-google-map-responsive" as |g|>
 
       {{#each-in this.locations key="id" as |id location|}}

--- a/docs/app/templates/docs/markers.hbs
+++ b/docs/app/templates/docs/markers.hbs
@@ -3,7 +3,10 @@
     <section>
       <h5 id="markers">Creating markers</h5>
 
-      <p>⚠️Note: As of February 21st, 2024 (v3.56), Marker is deprecated and <LinkTo @route="docs.advanced-markers" >Advanced Marker</LinkTo> is now preferred over marker.</p>
+      <DocDanger>
+        Google Maps <a href="https://developers.google.com/maps/deprecations#googlemapsmarker_in_the_deprecated_as_of_february_2024">has deprecated the Marker</a> as of February 21st, 2024 (v3.56).
+        The "legacy" marker currently still works, but you are encouradged to switch to the new <LinkTo @route="docs.advanced-markers" >Advanced Marker</LinkTo>.
+      </DocDanger>
 
       <p>You can create a basic marker with the yielded <var>marker</var> component. Once again, you can use either <var>lat</var> and <var>lng</var>, or <var>position</var>, to set the position.</p>
 

--- a/docs/code-snippets/advanced-markers.hbs
+++ b/docs/code-snippets/advanced-markers.hbs
@@ -1,4 +1,5 @@
 <GMap
+  @mapId="<YOUR MAPID"
   @lat="51.507568"
   @lng="-0.127762"
   @zoom={{9}} as |map|>
@@ -7,7 +8,7 @@
     <map.advancedMarker
       @lat={{location.lat}}
       @lng={{location.lng}}
-      @gmpDraggable={{true}}
+      @gmpDraggable={{false}}
       @onClick={{this.onClick}} />
   {{/each}}
 

--- a/docs/code-snippets/basic-markers.hbs
+++ b/docs/code-snippets/basic-markers.hbs
@@ -7,7 +7,7 @@
     <map.marker
       @lat={{location.lat}}
       @lng={{location.lng}}
-      @draggable={{true}}
+      @draggable={{false}}
       @onClick={{this.onClick}} />
   {{/each}}
 

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -130,7 +130,7 @@ devDependencies:
     version: file:..(ember-source@5.5.0)(webpack@5.89.0)
   ember-google-maps-markerclustererplus:
     specifier: ^1.0.1
-    version: 1.0.1(@babel/core@7.23.6)(ember-google-maps@7.1.0)(webpack@5.89.0)
+    version: 1.0.1(@babel/core@7.23.6)(ember-google-maps@7.2.0)(webpack@5.89.0)
   ember-load-initializers:
     specifier: ^2.1.2
     version: 2.1.2(@babel/core@7.23.6)
@@ -6703,7 +6703,7 @@ packages:
       - supports-color
     dev: true
 
-  /ember-google-maps-markerclustererplus@1.0.1(@babel/core@7.23.6)(ember-google-maps@7.1.0)(webpack@5.89.0):
+  /ember-google-maps-markerclustererplus@1.0.1(@babel/core@7.23.6)(ember-google-maps@7.2.0)(webpack@5.89.0):
     resolution: {integrity: sha512-vPLNBI7klqsCChbQvrvRoP5VmNB5hkMtrW9RqBXPlnAf/+42F/ZlkxfsXHWotanWnH/jkhZnOGb8DnhUdU22bw==}
     engines: {node: 10.* || >= 12}
     peerDependencies:

--- a/package.json
+++ b/package.json
@@ -57,8 +57,7 @@
     "ember-concurrency": "^3.1.1",
     "ember-modifier": "^4.1.0",
     "lodash": "^4.17.21",
-    "tracked-maps-and-sets": "^3.0.2",
-    "uuid": "^9.0.1"
+    "tracked-maps-and-sets": "^3.0.2"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.23.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,9 +50,6 @@ dependencies:
   tracked-maps-and-sets:
     specifier: ^3.0.2
     version: 3.0.2
-  uuid:
-    specifier: ^9.0.1
-    version: 9.0.1
 
 devDependencies:
   '@babel/eslint-parser':
@@ -12143,11 +12140,6 @@ packages:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     hasBin: true
     dev: true
-
-  /uuid@9.0.1:
-    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
-    hasBin: true
-    dev: false
 
   /uvu@0.5.6:
     resolution: {integrity: sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==}

--- a/tests/integration/components/g-map/advanced-marker-test.js
+++ b/tests/integration/components/g-map/advanced-marker-test.js
@@ -11,9 +11,13 @@ module('Integration | Component | g map/advanced-marker', function (hooks) {
   setupMapTest(hooks);
   setupLocations(hooks);
 
+  hooks.before(function () {
+    this.mapId = 'ember-google-maps';
+  });
+
   test('it renders an advanced-marker', async function (assert) {
     await render(hbs`
-      <GMap @lat={{this.lat}} @lng={{this.lng}} as |g|>
+      <GMap @lat={{this.lat}} @lng={{this.lng}} @mapId={{this.mapId}} as |g|>
         <g.advancedMarker @lat={{this.lat}} @lng={{this.lng}} />
       </GMap>
     `);
@@ -35,7 +39,7 @@ module('Integration | Component | g map/advanced-marker', function (hooks) {
     this.onClick = () => assert.ok('It binds events to actions');
 
     await render(hbs`
-      <GMap @lat={{this.lat}} @lng={{this.lng}} as |g|>
+      <GMap @lat={{this.lat}} @lng={{this.lng}} @mapId={{this.mapId}} as |g|>
         <g.advancedMarker @lat={{this.lat}} @lng={{this.lng}} @onClick={{this.onClick}} />
       </GMap>
     `);
@@ -51,7 +55,7 @@ module('Integration | Component | g map/advanced-marker', function (hooks) {
 
   test('it sets options on an advanced marker', async function (assert) {
     await render(hbs`
-      <GMap @lat={{this.lat}} @lng={{this.lng}} as |g|>
+      <GMap @lat={{this.lat}} @lng={{this.lng}} @mapId={{this.mapId}} as |g|>
         <g.advancedMarker @lat={{this.lat}} @lng={{this.lng}} @gmpDraggable={{true}} />
       </GMap>
     `);
@@ -71,7 +75,7 @@ module('Integration | Component | g map/advanced-marker', function (hooks) {
     this.set('showMarker', true);
 
     await render(hbs`
-      <GMap @lat={{this.lat}} @lng={{this.lng}} as |g|>
+      <GMap @lat={{this.lat}} @lng={{this.lng}} @mapId={{this.mapId}} as |g|>
         {{#if this.showMarker}}
           <g.advancedMarker @lat={{this.lat}} @lng={{this.lng}} @gmpDraggable={{true}} />
         {{/if}}
@@ -98,7 +102,7 @@ module('Integration | Component | g map/advanced-marker', function (hooks) {
     });
 
     await render(hbs`
-      <GMap @lat={{this.lat}} @lng={{this.lng}} as |g|>
+      <GMap @lat={{this.lat}} @lng={{this.lng}} @mapId={{this.mapId}} as |g|>
         <g.advancedMarker @lat={{this.markerLat}} @lng={{this.markerLng}}/>
       </GMap>
     `);


### PR DESCRIPTION
An auto-generated `mapId` was added together with the [advanced marker
feature](#192). This should not have been done as the `mapId` is specifically
used for cloud styling and breaks "legacy" styling.